### PR TITLE
Review Finding Mitigation: emit_SanctionedAccountAssetsQueuedForWithdrawal corrupts free pointer

### DIFF
--- a/src/libraries/MarketEvents.sol
+++ b/src/libraries/MarketEvents.sol
@@ -63,10 +63,12 @@ function emit_SanctionedAccountAssetsQueuedForWithdrawal(
   uint256 normalizedAmount
 ) {
   assembly {
+    let freePointer := mload(0x40)
     mstore(0, expiry)
     mstore(0x20, scaledAmount)
     mstore(0x40, normalizedAmount)
     log2(0, 0x60, 0xe12b220b92469ae28fb0d79de531f94161431be9f073b96b8aad3effb88be6fa, account)
+    mstore(0x40, freePointer)
   }
 }
 


### PR DESCRIPTION
### Finding

Violet's security review found the following issue:

It is best practice to reset the free memory pointer at the end of `emit_SanctionedAccountAssetsQueuedForWithdrawal`, currently this memory corruption has no effect because the emission is right before the end of the function, but it is a rough edge which can easily cause errors on small refactors.

### Mitigation

Cache and restore free pointer. Fixing in case the function is used in the future in another context that is not at the end of the external function.