### PR TITLE
Fix: Scope isKnownLender to specific markets

### DIFF
--- a/src/types/LenderStatus.sol
+++ b/src/types/LenderStatus.sol
@@ -4,15 +4,12 @@ import './RoleProvider.sol';
 
 /**
  * @param isBlockedFromDeposits   Whether the lender is blocked from depositing
- * @param isKnownLender           Whether the lender has irrevocable permission to withdraw & receive
- *                                tokens for market.
  * @param lastProvider            The address of the last provider to grant the lender a credential
  * @param canRefresh              Whether the last provider can refresh the lender's credential
  * @param lastApprovalTimestamp   The timestamp at which the lender's credential was granted
  */
 struct LenderStatus {
   bool isBlockedFromDeposits;
-  bool isKnownLender;
   address lastProvider;
   bool canRefresh;
   uint32 lastApprovalTimestamp;

--- a/test/access/AccessControlHooks.t.sol
+++ b/test/access/AccessControlHooks.t.sol
@@ -51,7 +51,7 @@ contract AccessControlHooksTest is Test, Assertions, Prankster {
   }
 
   function _getIsKnownLenderStatus(AccessControlHooksFuzzContext memory context) internal {
-    hooks.setIsKnownLender(context.account, true);
+    hooks.setIsKnownLender(context.account, context.market, true);
   }
 
   function test_onCreateMarket_ForceEnableDepositTransferHooks() external {
@@ -507,6 +507,7 @@ contract AccessControlHooksTest is Test, Assertions, Prankster {
   ) external {
     AccessControlHooksFuzzContext memory context = createAccessControlHooksFuzzContext(
       fuzzInputs,
+      address(1),
       hooks,
       mockProvider1,
       mockProvider2,

--- a/test/helpers/Assertions.sol
+++ b/test/helpers/Assertions.sol
@@ -286,7 +286,6 @@ contract Assertions is StdAssertions {
       expected.isBlockedFromDeposits,
       string.concat(key, '.isBlockedFromDeposits')
     );
-    assertEq(actual.isKnownLender, expected.isKnownLender, string.concat(key, '.isKnownLender'));
     assertEq(actual.lastProvider, expected.lastProvider, string.concat(key, '.lastProvider'));
     assertEq(actual.canRefresh, expected.canRefresh, string.concat(key, '.canRefresh'));
     assertEq(

--- a/test/market/WildcatMarket.t.sol
+++ b/test/market/WildcatMarket.t.sol
@@ -437,15 +437,13 @@ contract WildcatMarketTest is BaseMarketTest {
   /// @dev Helper for fuzz tests to acquire `isKnownLender` while keeping the expected
   //       market state up-to-date. Fuzz library will handle acquiring permission to
   //       execute a deposit if it is required.
-  function _getKnownLenderStatus(
-    AccessControlHooksFuzzContext memory context
-  ) internal {
+  function _getKnownLenderStatus(AccessControlHooksFuzzContext memory context) internal {
     MarketState memory state = _toMarketState(context.getKnownLenderInputParameter);
     uint amount = 1e18;
     address depositor = context.config.useOnDeposit
       ? context.account
       : (context.account == alice ? bob : alice);
-      safeStartPrank(depositor);
+    safeStartPrank(depositor);
     (uint256 currentScaledBalance, uint256 currentBalance) = _getBalance(state, depositor);
     asset.mint(depositor, amount);
     asset.approve(address(market), amount);
@@ -489,6 +487,7 @@ contract WildcatMarketTest is BaseMarketTest {
     MarketState memory state = pendingState();
     AccessControlHooksFuzzContext memory context = createAccessControlHooksFuzzContext(
       fuzzInputs,
+      address(market),
       hooks,
       roleProvider1,
       roleProvider2,
@@ -578,6 +577,7 @@ contract WildcatMarketTest is BaseMarketTest {
     market.transfer(carol, amount);
     AccessControlHooksFuzzContext memory context = createAccessControlHooksFuzzContext(
       fuzzInputs,
+      address(market),
       hooks,
       roleProvider1,
       roleProvider2,
@@ -708,7 +708,7 @@ contract WildcatMarketTest is BaseMarketTest {
     vm.prank(alice);
     market.transfer(bob, 0.5e18);
     LenderStatus memory status = hooks.getPreviousLenderStatus(bob);
-    assertTrue(status.isKnownLender, 'bob.isKnownLender');
+    assertTrue(hooks.isKnownLenderOnMarket(bob, address(market)), 'bob.isKnownLender');
   }
 
   function test_transfer_ToBlockedKnownLender() external {
@@ -717,7 +717,7 @@ contract WildcatMarketTest is BaseMarketTest {
     vm.prank(alice);
     market.transfer(bob, 0.5e18);
     LenderStatus memory status = hooks.getPreviousLenderStatus(bob);
-    assertTrue(status.isKnownLender, 'bob.isKnownLender');
+    assertTrue(hooks.isKnownLenderOnMarket(bob, address(market)), 'bob.isKnownLender');
     _blockLender(bob);
     vm.prank(alice);
     market.transfer(bob, 0.5e18);


### PR DESCRIPTION
Remove `isKnownLender` from `LenderStatus` and put it in a separate mapping so that it is scoped to individual markets.