### PR TITLE
Introduce force buyback feature

### DIFF
--- a/src/access/FixedTermLoanHooks.sol
+++ b/src/access/FixedTermLoanHooks.sol
@@ -92,6 +92,7 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
   error WithdrawBeforeTermEnd();
   error NoReducingAprBeforeTermEnd();
   error TransfersDisabled();
+  error ForceBuyBacksDisabled();
 
   // ========================================================================== //
   //                                    State                                   //
@@ -1024,4 +1025,13 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
     MarketState memory /* intermediateState */,
     bytes calldata /* extraData */
   ) external override {}
+
+  function onForceBuyBack(
+    address lender,
+    uint scaledAmount,
+    MarketState calldata intermediateState,
+    bytes calldata extraData
+  ) external virtual override {
+    revert ForceBuyBacksDisabled();
+  }
 }

--- a/src/access/IHooks.sol
+++ b/src/access/IHooks.sol
@@ -54,6 +54,13 @@ abstract contract IHooks {
     bytes calldata extraData
   ) external virtual;
 
+  function onForceBuyBack(
+    address lender,
+    uint scaledAmount,
+    MarketState calldata intermediateState,
+    bytes calldata extraData
+  ) external virtual;
+
   function onExecuteWithdrawal(
     address lender,
     uint128 normalizedAmountWithdrawn,

--- a/src/interfaces/IMarketEventsAndErrors.sol
+++ b/src/interfaces/IMarketEventsAndErrors.sol
@@ -42,11 +42,17 @@ interface IMarketEventsAndErrors {
 
   error NullRepayAmount();
 
+  error NullBuyBackAmount();
+
   error MarketAlreadyClosed();
 
   error DepositToClosedMarket();
 
   error RepayToClosedMarket();
+
+  error BuyBackOnClosedMarket();
+
+  error BuyBackOnDelinquentMarket();
 
   error BorrowWhileSanctioned();
 
@@ -157,6 +163,8 @@ interface IMarketEventsAndErrors {
     address indexed account,
     uint256 normalizedAmount
   );
+
+  event ForceBuyBack(address indexed lender, uint256 scaledAmount, uint256 normalizedAmount);
 
   event SanctionedAccountWithdrawalSentToEscrow(
     address indexed account,

--- a/src/libraries/MarketErrors.sol
+++ b/src/libraries/MarketErrors.sol
@@ -206,6 +206,16 @@ function revert_NullRepayAmount() pure {
   }
 }
 
+uint256 constant NullBuyBackAmount_ErrorSelector = 0x50394120;
+
+/// @dev Equivalent to `revert NullBuyBackAmount()`
+function revert_NullBuyBackAmount() pure {
+  assembly {
+    mstore(0, 0x50394120)
+    revert(0x1c, 0x04)
+  }
+}
+
 uint256 constant DepositToClosedMarket_ErrorSelector = 0x22d7c043;
 
 /// @dev Equivalent to `revert DepositToClosedMarket()`
@@ -222,6 +232,26 @@ uint256 constant RepayToClosedMarket_ErrorSelector = 0x61d1bc8f;
 function revert_RepayToClosedMarket() pure {
   assembly {
     mstore(0, 0x61d1bc8f)
+    revert(0x1c, 0x04)
+  }
+}
+
+uint256 constant BuyBackOnClosedMarket_Selector = 0xf788d279;
+
+/// @dev Equivalent to `revert BuyBackOnClosedMarket()`
+function revert_BuyBackOnClosedMarket() pure {
+  assembly {
+    mstore(0, 0xf788d279)
+    revert(0x1c, 0x04)
+  }
+}
+
+uint256 constant BuyBackOnDelinquentMarket_Selector = 0x1707a7b7;
+
+/// @dev Equivalent to `revert BuyBackOnDelinquentMarket()`
+function revert_BuyBackOnDelinquentMarket() pure {
+  assembly {
+    mstore(0, 0x1707a7b7)
     revert(0x1c, 0x04)
   }
 }

--- a/src/libraries/MarketEvents.sol
+++ b/src/libraries/MarketEvents.sol
@@ -225,6 +225,14 @@ function emit_WithdrawalExecuted(uint256 expiry, address account, uint256 normal
   }
 }
 
+function emit_ForceBuyBack(address lender, uint256 scaledAmount, uint256 normalizedAmount) {
+  assembly {
+    mstore(0, scaledAmount)
+    mstore(0x20, normalizedAmount)
+    log2(0, 0x40, 0xec42dcb09f4ea95e4ca97cd893ccde457527d1517648ef8cf3fc5bc65a77caf4, lender)
+  }
+}
+
 function emit_SanctionedAccountWithdrawalSentToEscrow(
   address account,
   address escrow,

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -200,6 +200,32 @@ contract WildcatMarket is
     _writeState(state);
   }
 
+  function forceBuyBack(address lender, uint256 normalizedAmount) external onlyBorrower {
+    MarketState memory state = _getUpdatedState();
+    if (state.isClosed) revert_BuyBackOnClosedMarket();
+    if (state.isDelinquent) revert_BuyBackOnDelinquentMarket();
+
+    uint104 scaledAmount = state.scaleAmount(normalizedAmount).toUint104();
+    if (scaledAmount == 0) revert_NullBuyBackAmount();
+
+    hooks.onForceBuyBack(lender, scaledAmount, state);
+
+    asset.safeTransferFrom(msg.sender, lender, normalizedAmount);
+
+    Account memory from = _accounts[lender];
+    from.scaledBalance -= scaledAmount;
+    _accounts[lender] = from;
+
+    Account memory to = _accounts[msg.sender];
+    to.scaledBalance += scaledAmount;
+    _accounts[msg.sender] = to;
+
+    emit_Transfer(lender, msg.sender, scaledAmount);
+    emit_ForceBuyBack(lender, scaledAmount, normalizedAmount);
+
+    _writeState(state);
+  }
+
   /**
    * @dev Sets the market APR to 0% and marks market as closed.
    *

--- a/src/types/HooksConfig.sol
+++ b/src/types/HooksConfig.sol
@@ -718,7 +718,10 @@ library LibHooksConfig {
     );
     if (self.useOnSetAnnualInterestAndReserveRatioBips()) {
       assembly {
-        let extraCalldataBytes := sub(calldatasize(), SetAnnualInterestAndReserveRatioBipsCalldataSize)
+        let extraCalldataBytes := sub(
+          calldatasize(),
+          SetAnnualInterestAndReserveRatioBipsCalldataSize
+        )
         let cdPointer := mload(0x40)
         let headPointer := add(cdPointer, 0x20)
         // Write selector for `onSetAnnualInterestBips`
@@ -784,7 +787,11 @@ library LibHooksConfig {
   uint256 internal constant SetProtocolFeeBips_ExtraData_Length_Offset = 0x0200;
   uint256 internal constant SetProtocolFeeBips_ExtraData_TailOffset = 0x0220;
 
-  function onSetProtocolFeeBips(HooksConfig self, uint protocolFeeBips, MarketState memory state) internal {
+  function onSetProtocolFeeBips(
+    HooksConfig self,
+    uint protocolFeeBips,
+    MarketState memory state
+  ) internal {
     address target = self.hooksAddress();
     uint32 onSetProtocolFeeBipsSelector = uint32(IHooks.onSetProtocolFeeBips.selector);
     if (self.useOnSetProtocolFeeBips()) {
@@ -868,6 +875,62 @@ library LibHooksConfig {
           returndatacopy(0, 0, returndatasize())
           revert(0, returndatasize())
         }
+      }
+    }
+  }
+
+  // ========================================================================== //
+  //                           Hook for forced buyback                          //
+  // ========================================================================== //
+
+  uint256 internal constant ForceBuyBackCalldataSize = 0x44;
+  // Size of lender + scaledAmount + state + extraData.offset + extraData.length
+  uint256 internal constant ForceBuyBackHook_Base_Size = 0x0244;
+  uint256 internal constant ForceBuyBackHook_ScaledAmount_Offset = 0x20;
+  uint256 internal constant ForceBuyBackHook_State_Offset = 0x40;
+  uint256 internal constant ForceBuyBackHook_ExtraData_Head_Offset = 0x0200;
+  uint256 internal constant ForceBuyBackHook_ExtraData_Length_Offset = 0x0220;
+  uint256 internal constant ForceBuyBackHook_ExtraData_TailOffset = 0x0240;
+
+  function onForceBuyBack(
+    HooksConfig self,
+    address lender,
+    uint256 scaledAmount,
+    MarketState memory state
+  ) internal {
+    address target = self.hooksAddress();
+    uint32 onForceBuyBackSelector = uint32(IHooks.onForceBuyBack.selector);
+    assembly {
+      let extraCalldataBytes := sub(calldatasize(), ForceBuyBackCalldataSize)
+      let cdPointer := mload(0x40)
+      let headPointer := add(cdPointer, 0x20)
+      // Write selector for `onForceBuyBack`
+      mstore(cdPointer, onForceBuyBackSelector)
+      // Write `lender` to hook calldata
+      mstore(headPointer, lender)
+      // Write `scaledAmount` to hook calldata
+      mstore(add(headPointer, ForceBuyBackHook_ScaledAmount_Offset), scaledAmount)
+      // Copy market state to hook calldata
+      mcopy(add(headPointer, ForceBuyBackHook_State_Offset), state, MarketStateSize)
+      // Write bytes offset for `extraData`
+      mstore(
+        add(headPointer, ForceBuyBackHook_ExtraData_Head_Offset),
+        ForceBuyBackHook_ExtraData_Length_Offset
+      )
+      // Write length for `extraData`
+      mstore(add(headPointer, ForceBuyBackHook_ExtraData_Length_Offset), extraCalldataBytes)
+      // Copy `extraData` from end of calldata to hook calldata
+      calldatacopy(
+        add(headPointer, ForceBuyBackHook_ExtraData_TailOffset),
+        ForceBuyBackCalldataSize,
+        extraCalldataBytes
+      )
+
+      let size := add(ForceBuyBackHook_Base_Size, extraCalldataBytes)
+
+      if iszero(call(gas(), target, 0, add(cdPointer, 0x1c), size, 0, 0)) {
+        returndatacopy(0, 0, returndatasize())
+        revert(0, returndatasize())
       }
     }
   }

--- a/test/BaseMarketTest.sol
+++ b/test/BaseMarketTest.sol
@@ -132,10 +132,14 @@ contract BaseMarketTest is Test, ExpectedStateTracker {
     return _deposit(from, amount, true);
   }
 
-  function _requestWithdrawal(address from, uint256 amount) internal asAccount(from) {
+  function _requestWithdrawal(
+    address from,
+    uint256 amount
+  ) internal asAccount(from) returns (uint32 expiry) {
     MarketState memory state = pendingState();
     (uint256 currentScaledBalance, uint256 currentBalance) = _getBalance(state, from);
-    (, uint104 scaledAmount) = _trackQueueWithdrawal(state, from, amount);
+    uint104 scaledAmount;
+    (expiry, scaledAmount) = _trackQueueWithdrawal(state, from, amount);
     market.queueWithdrawal(amount);
     _checkState(state);
     assertApproxEqAbs(

--- a/test/access/FixedTermLoanHooks.t.sol
+++ b/test/access/FixedTermLoanHooks.t.sol
@@ -169,7 +169,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
       useOnTransfer: true,
       useOnBorrow: false,
       useOnRepay: false,
-      useOnCloseMarket: false,
+      useOnCloseMarket: true,
       useOnNukeFromOrbit: false,
       useOnSetMaxTotalSupply: false,
       useOnSetAnnualInterestAndReserveRatioBips: true,

--- a/test/helpers/ExpectedStateTracker.sol
+++ b/test/helpers/ExpectedStateTracker.sol
@@ -49,7 +49,9 @@ contract ExpectedStateTracker is Test, IMarketEventsAndErrors {
       deployMarketHooksData: '',
       hooksConfig: HooksConfig.wrap(0),
       sphereXEngine: address(0),
-      minimumDeposit: 0
+      minimumDeposit: 0,
+      transfersDisabled: false,
+      allowForceBuyBack: false
     });
   }
 

--- a/test/shared/Test.sol
+++ b/test/shared/Test.sol
@@ -40,6 +40,8 @@ struct MarketInputParameters {
   bytes deployMarketHooksData;
   HooksConfig hooksConfig;
   uint128 minimumDeposit;
+  bool transfersDisabled;
+  bool allowForceBuyBack;
 }
 
 contract Test is ForgeTest, Prankster, Assertions {
@@ -398,8 +400,12 @@ contract Test is ForgeTest, Prankster, Assertions {
   ) internal asAccount(parameters.borrower) returns (WildcatMarket) {
     updateFeeConfiguration(parameters);
 
-    if (parameters.deployMarketHooksData.length == 0 && parameters.minimumDeposit > 0) {
-      parameters.deployMarketHooksData = abi.encode(parameters.minimumDeposit);
+    if (parameters.deployMarketHooksData.length == 0) {
+      parameters.deployMarketHooksData = abi.encode(
+        parameters.minimumDeposit,
+        parameters.transfersDisabled,
+        parameters.allowForceBuyBack
+      );
     }
 
     bytes32 salt = _nextSalt(parameters.borrower);

--- a/test/shared/mocks/MockHooks.sol
+++ b/test/shared/mocks/MockHooks.sol
@@ -33,11 +33,7 @@ event OnTransferCalled(
 event OnBorrowCalled(uint normalizedAmount, MarketState intermediateState, bytes extraData);
 event OnRepayCalled(uint normalizedAmount, MarketState intermediateState, bytes extraData);
 event OnCloseMarketCalled(MarketState intermediateState, bytes extraData);
-event OnNukeFromOrbitCalled(
-  address lender,
-  MarketState intermediateState,
-  bytes extraData
-);
+event OnNukeFromOrbitCalled(address lender, MarketState intermediateState, bytes extraData);
 event OnSetMaxTotalSupplyCalled(
   uint256 maxTotalSupply,
   MarketState intermediateState,
@@ -51,6 +47,12 @@ event OnSetAnnualInterestAndReserveRatioBipsCalled(
 );
 event OnSetProtocolFeeBipsCalled(
   uint protocolFeeBips,
+  MarketState intermediateState,
+  bytes extraData
+);
+event OnForceBuyBackCalled(
+  address lender,
+  uint scaledAmount,
   MarketState intermediateState,
   bytes extraData
 );
@@ -229,11 +231,7 @@ contract MockHooks is IHooks {
     bytes calldata extraData
   ) external virtual override {
     lastCalldataHash = keccak256(msg.data);
-    emit OnNukeFromOrbitCalled(
-      lender,
-      intermediateState,
-      extraData
-    );
+    emit OnNukeFromOrbitCalled(lender, intermediateState, extraData);
   }
 
   function onSetMaxTotalSupply(
@@ -275,6 +273,16 @@ contract MockHooks is IHooks {
   ) external virtual override {
     lastCalldataHash = keccak256(msg.data);
     emit OnSetProtocolFeeBipsCalled(protocolFeeBips, intermediateState, extraData);
+  }
+
+  function onForceBuyBack(
+    address lender,
+    uint scaledAmount,
+    MarketState calldata intermediateState,
+    bytes calldata extraData
+  ) external virtual override {
+    lastCalldataHash = keccak256(msg.data);
+    emit OnForceBuyBackCalled(lender, scaledAmount, intermediateState, extraData);
   }
 }
 


### PR DESCRIPTION
Borrower can optionally enable force buybacks at market deployment when using `AccessControlHooks`.

Force buybacks are:
- Disabled on closed markets
- Disabled unless specifically enabled at deployment
- Disabled on delinquent markets