### PR TITLE
Change the SPDX identifier to indicate Commons Clause

### DIFF
--- a/src/HooksFactory.sol
+++ b/src/HooksFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import './libraries/LibERC20.sol';

--- a/src/IHooksFactory.sol
+++ b/src/IHooksFactory.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
 import './access/IHooks.sol';
 import './interfaces/WildcatStructsAndEnums.sol';
 

--- a/src/WildcatArchController.sol
+++ b/src/WildcatArchController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import { EnumerableSet } from 'openzeppelin/contracts/utils/structs/EnumerableSet.sol';

--- a/src/WildcatSanctionsEscrow.sol
+++ b/src/WildcatSanctionsEscrow.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import './interfaces/IERC20.sol';

--- a/src/WildcatSanctionsSentinel.sol
+++ b/src/WildcatSanctionsSentinel.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import { IChainalysisSanctionsList } from './interfaces/IChainalysisSanctionsList.sol';

--- a/src/access/AccessControlHooks.sol
+++ b/src/access/AccessControlHooks.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity ^0.8.20;
 
 import '../libraries/BoolUtils.sol';

--- a/src/access/FixedTermLoanHooks.sol
+++ b/src/access/FixedTermLoanHooks.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity ^0.8.20;
 
 import '../libraries/BoolUtils.sol';

--- a/src/access/MarketConstraintHooks.sol
+++ b/src/access/MarketConstraintHooks.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import './IHooks.sol';

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import './WildcatMarketBase.sol';

--- a/src/market/WildcatMarketBase.sol
+++ b/src/market/WildcatMarketBase.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import '../ReentrancyGuard.sol';

--- a/src/market/WildcatMarketConfig.sol
+++ b/src/market/WildcatMarketConfig.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import './WildcatMarketBase.sol';

--- a/src/market/WildcatMarketToken.sol
+++ b/src/market/WildcatMarketToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import './WildcatMarketBase.sol';

--- a/src/market/WildcatMarketWithdrawals.sol
+++ b/src/market/WildcatMarketWithdrawals.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
 pragma solidity >=0.8.20;
 
 import './WildcatMarketBase.sol';


### PR DESCRIPTION
This addresses issue #68.

The [Wildcat license](https://github.com/wildcat-finance/v2-protocol/blob/main/LICENSE.md) is Apache 2.0 modified by the [Commons Clause](https://commonsclause.com/). This is not reflected in the SPDX license identifiers of the smart contracts themselves, which give the impression from reading the contracts alone that Wildcat is proper Free Software.

Even though Wildcat's status as visible source can be readily determined from the Wildcat license visible in this repository and other locations, it is useful to have this fact immediately visible in the verified contract source code. For instance: I contribute to projects that attempt to quantify the degree to which major Ethereum applications are still Free Software by indexing verified contract source code.

I had to make a judgement call regarding what to use as an SPDX identifier for the Commons Clause, given that it does not have an existing identifier. A [codeslaw search](https://www.codeslaw.app/search?chain=ethereum&q=Commons+Clause) turns up prior usage of `Commons-Clause-1.0`, which seems good convention to follow. Because the Commons Clause does not have an existing identifier [we must prefix this](https://spdx.github.io/spdx-spec/v2-draft/SPDX-license-expressions/) with `LicenseRef` as a user-defined license. This is also an exception layered atop the existing Apache 2.0 license, so it is indicated using [`WITH` conventions](https://spdx.org/licenses/exceptions-index.html).

To that end, this pull request modifies the SPDX identifiers of some contracts to read `// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0`.

I have not modified all contracts:
- I left SphereX entirely alone because that is presumably not your code.
- I left your libraries entirely alone.
- I left your interfaces entirely alone, save for adding a standard `Apache-2.0` identifier to `IHooksFactory` which was otherwise missing one.
- I left your types alone; some of them are MIT-licensed so I assume you might have some legacy licensing to maintain there.
- I left d1ll0n's `ReentrancyGuard` alone because it's presumably sufficiently-trivial.