### PR TITLE
Force buyback changes - closes #72

### DIFF
--- a/src/access/AccessControlHooks.sol
+++ b/src/access/AccessControlHooks.sol
@@ -61,6 +61,7 @@ contract AccessControlHooks is MarketConstraintHooks {
   event AccountAccessRevoked(address indexed accountAddress);
   event AccountMadeFirstDeposit(address indexed market, address indexed accountAddress);
   event MinimumDepositUpdated(address market, uint128 newMinimumDeposit);
+  event DisabledForceBuyBacks(address market);
 
   // ========================================================================== //
   //                                   Errors                                   //
@@ -241,6 +242,15 @@ contract AccessControlHooks is MarketConstraintHooks {
     if (!hookedMarket.isHooked) revert NotHookedMarket();
     hookedMarket.minimumDeposit = newMinimumDeposit;
     emit MinimumDepositUpdated(market, newMinimumDeposit);
+  }
+
+  function disableForceBuyBacks(address market) external onlyBorrower {
+    HookedMarket storage hookedMarket = _hookedMarkets[market];
+    if (!hookedMarket.isHooked) revert NotHookedMarket();
+    if (hookedMarket.allowForceBuyBacks) {
+      hookedMarket.allowForceBuyBacks = false;
+      emit DisabledForceBuyBacks(market);
+    }
   }
 
   // ========================================================================== //

--- a/src/access/AccessControlHooks.sol
+++ b/src/access/AccessControlHooks.sol
@@ -993,10 +993,10 @@ contract AccessControlHooks is MarketConstraintHooks {
   ) external override {}
 
   function onForceBuyBack(
-    address lender,
-    uint scaledAmount,
-    MarketState calldata intermediateState,
-    bytes calldata extraData
+    address /* lender */,
+    uint /* scaledAmount */,
+    MarketState calldata /* intermediateState */,
+    bytes calldata /* extraData */
   ) external virtual override {
     HookedMarket memory market = _hookedMarkets[msg.sender];
     if (!market.isHooked) revert NotHookedMarket();

--- a/src/access/FixedTermLoanHooks.sol
+++ b/src/access/FixedTermLoanHooks.sol
@@ -66,10 +66,9 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
   );
   event AccountAccessRevoked(address indexed accountAddress);
   event AccountMadeFirstDeposit(address indexed market, address indexed accountAddress);
-
   event MinimumDepositUpdated(address market, uint128 newMinimumDeposit);
-
   event FixedTermUpdated(address market, uint32 fixedTermEndTime);
+  event DisabledForceBuyBacks(address market);
 
   // ========================================================================== //
   //                                   Errors                                   //
@@ -297,6 +296,15 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
     if (newFixedTermEndTime > hookedMarket.fixedTermEndTime) revert IncreaseFixedTerm();
     hookedMarket.fixedTermEndTime = newFixedTermEndTime;
     emit FixedTermUpdated(market, newFixedTermEndTime);
+  }
+
+  function disableForceBuyBacks(address market) external onlyBorrower {
+    HookedMarket storage hookedMarket = _hookedMarkets[market];
+    if (!hookedMarket.isHooked) revert NotHookedMarket();
+    if (hookedMarket.allowForceBuyBacks) {
+      hookedMarket.allowForceBuyBacks = false;
+      emit DisabledForceBuyBacks(market);
+    }
   }
 
   // ========================================================================== //

--- a/src/interfaces/IMarketEventsAndErrors.sol
+++ b/src/interfaces/IMarketEventsAndErrors.sol
@@ -162,7 +162,12 @@ interface IMarketEventsAndErrors {
     uint256 normalizedAmount
   );
 
-  event ForceBuyBack(address indexed lender, uint256 scaledAmount, uint256 normalizedAmount);
+  event ForceBuyBack(
+    address indexed lender,
+    uint256 scaledAmount,
+    uint256 normalizedAmount,
+    uint32 withdrawalExpiry
+  );
 
   event SanctionedAccountWithdrawalSentToEscrow(
     address indexed account,

--- a/src/interfaces/IMarketEventsAndErrors.sol
+++ b/src/interfaces/IMarketEventsAndErrors.sol
@@ -50,8 +50,6 @@ interface IMarketEventsAndErrors {
 
   error RepayToClosedMarket();
 
-  error BuyBackOnClosedMarket();
-
   error BuyBackOnDelinquentMarket();
 
   error BorrowWhileSanctioned();

--- a/src/lens/HooksConfigData.sol
+++ b/src/lens/HooksConfigData.sol
@@ -45,7 +45,6 @@ struct MarketHooksData {
   bool depositRequiresAccess;
   uint128 minimumDeposit;
   bool transfersDisabled;
-  // Access control flags
   bool allowForceBuyBacks;
   // Fixed term loan flags
   bool withdrawalRequiresAccess;
@@ -84,6 +83,7 @@ library HooksConfigDataLib {
       data.transfersDisabled = hookedMarket.transfersDisabled;
       data.allowClosureBeforeTerm = hookedMarket.allowClosureBeforeTerm;
       data.allowTermReduction = hookedMarket.allowTermReduction;
+      data.allowForceBuyBacks = hookedMarket.allowForceBuyBacks;
     }
   }
 

--- a/src/libraries/MarketErrors.sol
+++ b/src/libraries/MarketErrors.sol
@@ -236,16 +236,6 @@ function revert_RepayToClosedMarket() pure {
   }
 }
 
-uint256 constant BuyBackOnClosedMarket_Selector = 0xf788d279;
-
-/// @dev Equivalent to `revert BuyBackOnClosedMarket()`
-function revert_BuyBackOnClosedMarket() pure {
-  assembly {
-    mstore(0, 0xf788d279)
-    revert(0x1c, 0x04)
-  }
-}
-
 uint256 constant BuyBackOnDelinquentMarket_Selector = 0x1707a7b7;
 
 /// @dev Equivalent to `revert BuyBackOnDelinquentMarket()`

--- a/src/libraries/MarketEvents.sol
+++ b/src/libraries/MarketEvents.sol
@@ -225,11 +225,12 @@ function emit_WithdrawalExecuted(uint256 expiry, address account, uint256 normal
   }
 }
 
-function emit_ForceBuyBack(address lender, uint256 scaledAmount, uint256 normalizedAmount) {
+function emit_ForceBuyBack(address lender, uint256 scaledAmount, uint256 normalizedAmount, uint32 withdrawalExpiry) {
   assembly {
     mstore(0, scaledAmount)
     mstore(0x20, normalizedAmount)
-    log2(0, 0x40, 0xec42dcb09f4ea95e4ca97cd893ccde457527d1517648ef8cf3fc5bc65a77caf4, lender)
+    mstore(0x40, withdrawalExpiry)
+    log2(0, 0x60, 0xd26ddbc1840a7e87449ec6172fa0ba67fadecc95a60ab7ec01d8f712b4d8cda3, lender)
   }
 }
 

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -220,9 +220,9 @@ contract WildcatMarket is
     _accounts[msg.sender] = to;
 
     emit_Transfer(lender, msg.sender, normalizedAmount);
-    emit_ForceBuyBack(lender, scaledAmount, normalizedAmount);
 
-    _writeState(state);
+    uint32 expiry = _queueWithdrawal(state, to, msg.sender, scaledAmount, normalizedAmount, _runtimeConstant(0x44));
+    emit_ForceBuyBack(lender, scaledAmount, normalizedAmount, expiry);
   }
 
   /**

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -220,7 +220,7 @@ contract WildcatMarket is
     to.scaledBalance += scaledAmount;
     _accounts[msg.sender] = to;
 
-    emit_Transfer(lender, msg.sender, scaledAmount);
+    emit_Transfer(lender, msg.sender, normalizedAmount);
     emit_ForceBuyBack(lender, scaledAmount, normalizedAmount);
 
     _writeState(state);

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -202,7 +202,6 @@ contract WildcatMarket is
 
   function forceBuyBack(address lender, uint256 normalizedAmount) external nonReentrant onlyBorrower {
     MarketState memory state = _getUpdatedState();
-    if (state.isClosed) revert_BuyBackOnClosedMarket();
     if (state.isDelinquent) revert_BuyBackOnDelinquentMarket();
 
     uint104 scaledAmount = state.scaleAmount(normalizedAmount).toUint104();

--- a/src/types/HooksConfig.sol
+++ b/src/types/HooksConfig.sol
@@ -87,7 +87,7 @@ library LibHooksConfig {
   ) internal pure returns (HooksConfig updatedHooks) {
     assembly {
       // Shift twice to clear the address
-      updatedHooks := shr(96, shl(96, hooks))
+      updatedHooks := shr(160, shl(160, hooks))
       // Set the new address
       updatedHooks := or(updatedHooks, shl(96, _hooksAddress))
     }

--- a/test/BaseMarketTest.sol
+++ b/test/BaseMarketTest.sol
@@ -205,4 +205,93 @@ contract BaseMarketTest is Test, ExpectedStateTracker {
   function _approve(address from, address to, uint256 amount) internal asAccount(from) {
     asset.approve(to, amount);
   }
+
+  // function applyFuzzedHooksConfig(MarketHooksConfigFuzzInputs memory inputs) internal {
+  //   inputs.minimumDeposit = uint128(bound(inputs.minimumDeposit, 0, parameters.maxTotalSupply));
+  //   if (inputs.isAccessControlHooks) {
+  //     inputs.allowClosureBeforeTerm = false;
+  //     inputs.allowTermReduction = false;
+  //     inputs.fixedTermDuration = 0;
+  //   } else {
+  //     inputs.fixedTermDuration = uint16(bound(inputs.fixedTermDuration, 1, type(uint16).max));
+  //   }
+
+  //   parameters.minimumDeposit = inputs.minimumDeposit;
+  //   parameters.transfersDisabled = inputs.transfersDisabled;
+  //   parameters.allowForceBuyBack = inputs.allowForceBuyBacks;
+  //   parameters.fixedTermEndTime = inputs.isAccessControlHooks
+  //     ? 0
+  //     : uint32(inputs.fixedTermDuration + block.timestamp);
+  //   parameters.allowClosureBeforeTerm = inputs.allowClosureBeforeTerm;
+  //   parameters.allowTermReduction = inputs.allowTermReduction;
+
+  //   parameters.hooksConfig = encodeHooksConfig({
+  //     hooksAddress: address(hooks),
+  //     useOnDeposit: inputs.useOnDeposit,
+  //     useOnQueueWithdrawal: inputs.useOnQueueWithdrawal,
+  //     useOnExecuteWithdrawal: false,
+  //     useOnTransfer: inputs.useOnTransfer,
+  //     useOnBorrow: false,
+  //     useOnRepay: false,
+  //     useOnCloseMarket: false,
+  //     useOnNukeFromOrbit: false,
+  //     useOnSetMaxTotalSupply: false,
+  //     useOnSetAnnualInterestAndReserveRatioBips: true,
+  //     useOnSetProtocolFeeBips: false
+  //   });
+  //   resetWithNewHooks(inputs.isAccessControlHooks ? HooksKind.AccessControl : HooksKind.FixedTerm);
+  // }
+
+  function applyFuzzedHooksConfig(MarketHooksConfigFuzzInputs memory inputs) internal {
+    inputs.minimumDeposit = uint128(bound(inputs.minimumDeposit, 0, parameters.maxTotalSupply));
+    if (inputs.isAccessControlHooks) {
+      inputs.allowClosureBeforeTerm = false;
+      inputs.allowTermReduction = false;
+      inputs.fixedTermDuration = 0;
+    } else {
+      inputs.fixedTermDuration = uint16(bound(inputs.fixedTermDuration, 1, type(uint16).max));
+    }
+
+    // parameters.hooksTemplate = inputs.isAccessControlHooks ? hooksTemplate : fixedTermHooksTemplate;
+    // parameters.deployMarketHooksData = '';
+    parameters.minimumDeposit = inputs.minimumDeposit;
+    parameters.transfersDisabled = inputs.transfersDisabled;
+    parameters.allowForceBuyBack = inputs.allowForceBuyBacks;
+    parameters.fixedTermEndTime = inputs.isAccessControlHooks
+      ? 0
+      : uint32(inputs.fixedTermDuration + block.timestamp);
+    parameters.allowClosureBeforeTerm = inputs.allowClosureBeforeTerm;
+    parameters.allowTermReduction = inputs.allowTermReduction;
+
+    // hooks = AccessControlHooks(address(0));
+
+    parameters.hooksConfig = encodeHooksConfig({
+      hooksAddress: address(0),
+      useOnDeposit: inputs.useOnDeposit,
+      useOnQueueWithdrawal: inputs.useOnQueueWithdrawal,
+      useOnExecuteWithdrawal: false,
+      useOnTransfer: inputs.useOnTransfer,
+      useOnBorrow: false,
+      useOnRepay: false,
+      useOnCloseMarket: false,
+      useOnNukeFromOrbit: false,
+      useOnSetMaxTotalSupply: false,
+      useOnSetAnnualInterestAndReserveRatioBips: true,
+      useOnSetProtocolFeeBips: false
+    });
+    // setUpContracts(false);
+    resetWithNewHooks(inputs.isAccessControlHooks ? HooksKind.AccessControl : HooksKind.FixedTerm);
+  }
+
+  function resetWithNewHooks(HooksKind kind) internal {
+    if (kind == HooksKind.AccessControl) {
+      parameters.hooksTemplate = hooksTemplate;
+    } else if (kind == HooksKind.FixedTerm) {
+      parameters.hooksTemplate = fixedTermHooksTemplate;
+    }
+    parameters.deployMarketHooksData = '';
+    hooks = AccessControlHooks(address(0));
+    parameters.hooksConfig = parameters.hooksConfig.setHooksAddress(address(0));
+    setUpContracts(false);
+  }
 }

--- a/test/HooksIntegration.t.sol
+++ b/test/HooksIntegration.t.sol
@@ -564,9 +564,6 @@ contract HooksIntegrationTest is BaseMarketTest {
     // _depositBorrowWithdraw(alice, 1e18, 8e17, 1e18);
     MockHooks(address(hooks)).reset();
     startPrank(borrower);
-    // asset.mint(borrower, 1e18);
-    // asset.approve(address(market), 1e18);
-    // _setUp(config);
     _deposit(lender, 1e18, true);
     MockHooks(address(hooks)).reset();
     asset.mint(borrower, 1e18);
@@ -578,10 +575,6 @@ contract HooksIntegrationTest is BaseMarketTest {
     );
     vm.expectEmit(address(hooks));
     emit OnForceBuyBackCalled(lender, 1e18, state, extraData);
-    vm.expectEmit(address(asset));
-    emit IERC20.Transfer(borrower, lender, 1e18);
-    vm.expectEmit(address(market));
-    emit IERC20.Transfer(lender, borrower, 1e18);
     _callMarket(_calldata, '', 'forceBuyBack');
   }
 }

--- a/test/access/FixedTermLoanHooks.t.sol
+++ b/test/access/FixedTermLoanHooks.t.sol
@@ -331,7 +331,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
       address(this),
       address(1),
       inputs,
-      abi.encode(block.timestamp + 365 days, 1e18, false, false, true)
+      abi.encode(block.timestamp + 365 days, 1e18, false, false, false, true)
     );
     vm.expectEmit(address(hooks));
     emit FixedTermLoanHooks.FixedTermUpdated(address(1), uint32(block.timestamp + 364 days));
@@ -349,7 +349,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
       address(this),
       address(1),
       inputs,
-      abi.encode(block.timestamp + 365 days, 1e18, false, false, false)
+      abi.encode(block.timestamp + 365 days, 1e18, false, false, false, false)
     );
     vm.expectRevert(FixedTermLoanHooks.TermReductionDisabled.selector);
     hooks.setFixedTermEndTime(address(1), uint32(block.timestamp + 364 days));
@@ -1099,7 +1099,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
       address(this),
       address(1),
       inputs,
-      abi.encode(block.timestamp + 365 days, 1e18, false, true)
+      abi.encode(block.timestamp + 365 days, 1e18, false, false, true)
     );
     vm.prank(address(1));
     vm.expectEmit(address(hooks));
@@ -1110,7 +1110,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
     assertEq(market.fixedTermEndTime, uint32(block.timestamp), 'fixedTermEndTime');
   }
 
-  function test_closeMarket_ClosureDisabledBeforeTerm()external {
+  function test_closeMarket_ClosureDisabledBeforeTerm() external {
     DeployMarketInputs memory inputs;
     inputs.hooks = EmptyHooksConfig.setFlag(Bit_Enabled_QueueWithdrawal).setHooksAddress(
       address(hooks)
@@ -1119,7 +1119,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
       address(this),
       address(1),
       inputs,
-      abi.encode(block.timestamp + 365 days, 1e18, false, false)
+      abi.encode(block.timestamp + 365 days, 1e18, false, false, false)
     );
     vm.prank(address(1));
     vm.expectRevert(FixedTermLoanHooks.ClosureDisabledBeforeTerm.selector);
@@ -1128,7 +1128,6 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
   }
 
   function test_forceBuyBack_ForceBuyBacksDisabled() external {
-    
     DeployMarketInputs memory inputs;
     inputs.hooks = EmptyHooksConfig.setFlag(Bit_Enabled_QueueWithdrawal).setHooksAddress(
       address(hooks)
@@ -1141,6 +1140,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
     );
     vm.expectRevert(FixedTermLoanHooks.ForceBuyBacksDisabled.selector);
     MarketState memory state;
-    hooks.onForceBuyBack(address(1), 0, state, '');
+    vm.prank(address(1));
+    hooks.onForceBuyBack(address(2), 0, state, '');
   }
 }

--- a/test/helpers/PRNG.sol
+++ b/test/helpers/PRNG.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.20;
 
+import { bound } from './VmUtils.sol';
+
 type PRNG is uint256;
 using LibPRNG for PRNG global;
 
@@ -33,6 +35,18 @@ library LibPRNG {
       result := keccak256(self, 0x20)
       mstore(self, result)
     }
+  }
+
+  function next(PRNG self, uint256 min, uint256 max) internal pure returns (uint256) {
+    return bound(self.next(), min, max);
+  }
+
+  function nextBool(PRNG self) internal pure returns (bool) {
+    return bound(self.next(), 0, 1) == 1;
+  }
+
+  function nextEnum(PRNG self, uint8 min, uint8 max) internal pure returns (uint8) {
+    return uint8(bound(self.next(), min, max));
   }
 
   /// @dev Returns the next `length` bytes of pseudorandom data.

--- a/test/market/WildcatMarket.t.sol
+++ b/test/market/WildcatMarket.t.sol
@@ -509,13 +509,7 @@ contract WildcatMarketTest is BaseMarketTest {
         fastForward(parameters.fixedTermEndTime - block.timestamp);
       }
       MarketState memory state = pendingState(true);
-      uint scaledAmount = state.scaleAmount(amount);
-      vm.expectEmit(address(asset));
-      emit IMarketEventsAndErrors.Transfer(borrower, alice, amount);
-      vm.expectEmit(address(market));
-      emit IMarketEventsAndErrors.Transfer(alice, borrower, amount);
-      vm.expectEmit(address(market));
-      emit IMarketEventsAndErrors.ForceBuyBack(alice, scaledAmount, amount);
+      _trackForceBuyBack(state, alice, amount);
     }
     market.forceBuyBack(alice, amount);
   }
@@ -722,12 +716,9 @@ contract WildcatMarketTest is BaseMarketTest {
     _deposit(alice, 1e18);
     asset.approve(address(market), 1e17);
     asset.mint(borrower, 1e17);
-    vm.expectEmit(address(asset));
-    emit IMarketEventsAndErrors.Transfer(borrower, alice, 1e17);
-    vm.expectEmit(address(market));
-    emit IMarketEventsAndErrors.Transfer(alice, borrower, 1e17);
-    vm.expectEmit(address(market));
-    emit IMarketEventsAndErrors.ForceBuyBack(alice, 1e17, 1e17);
+    MarketState memory state = pendingState(true);
+
+    _trackForceBuyBack(state, alice, 1e17);
     market.forceBuyBack(alice, 1e17);
   }
 }

--- a/test/market/WildcatMarket.t.sol
+++ b/test/market/WildcatMarket.t.sol
@@ -691,12 +691,6 @@ contract WildcatMarketTest is BaseMarketTest {
     market.forceBuyBack(alice, 0);
   }
 
-  function test_forceBuyBack_BuyBackOnClosedMarket() external asAccount(borrower) {
-    market.closeMarket();
-    vm.expectRevert(IMarketEventsAndErrors.BuyBackOnClosedMarket.selector);
-    market.forceBuyBack(alice, 1e18);
-  }
-
   function test_forceBuyBack_BuyBackOnDelinquentMarket() external asAccount(borrower) {
     _depositBorrowWithdraw(alice, 1e18, 8e17, 3e17);
     vm.expectRevert(IMarketEventsAndErrors.BuyBackOnDelinquentMarket.selector);


### PR DESCRIPTION
- Allow `forceBuyBack` on closed markets
  - Remove error from interface
  - Remove library function for error
  - Remove revert
- Allow `forceBuyBack` on fixed term markets that have converted to open term
  - Update HookedMarket and constructor params in FixedTermLoanHooks
  - Update validation and deployment in tests
  - Update lens
- `forceBuyBack` should immediately trigger a wd request from the borrower
- Add function to disable `forceBuyBack` for a deployed market
- Fix `setHooksAddress` clearing wrong number of bits (closes #63)