### PR TITLE
Removing additional tests, hooks and hiding forceBuyback function

### DIFF
--- a/src/access/AccessControlHooks.sol
+++ b/src/access/AccessControlHooks.sol
@@ -993,6 +993,7 @@ contract AccessControlHooks is MarketConstraintHooks {
     bytes calldata /* extraData */
   ) external override {}
 
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
@@ -1015,4 +1016,5 @@ contract AccessControlHooks is MarketConstraintHooks {
       );
     }
   }
+  */
 }

--- a/src/access/FixedTermLoanHooks.sol
+++ b/src/access/FixedTermLoanHooks.sol
@@ -1069,6 +1069,7 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
     bytes calldata /* extraData */
   ) external override {}
 
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
@@ -1077,4 +1078,5 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
   ) external virtual override {
     revert ForceBuyBacksDisabled();
   }
+  */
 }

--- a/src/access/IHooks.sol
+++ b/src/access/IHooks.sol
@@ -54,13 +54,15 @@ abstract contract IHooks {
     bytes calldata extraData
   ) external virtual;
 
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
     MarketState calldata intermediateState,
     bytes calldata extraData
   ) external virtual;
-
+  */
+ 
   function onExecuteWithdrawal(
     address lender,
     uint128 normalizedAmountWithdrawn,

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -200,6 +200,7 @@ contract WildcatMarket is
     _writeState(state);
   }
 
+  /*
   function forceBuyBack(address lender, uint256 normalizedAmount) external nonReentrant onlyBorrower {
     MarketState memory state = _getUpdatedState();
     if (state.isClosed) revert_BuyBackOnClosedMarket();
@@ -225,7 +226,8 @@ contract WildcatMarket is
 
     _writeState(state);
   }
-
+  */
+ 
   /**
    * @dev Sets the market APR to 0% and marks market as closed.
    *

--- a/src/types/HooksConfig.sol
+++ b/src/types/HooksConfig.sol
@@ -878,7 +878,8 @@ library LibHooksConfig {
       }
     }
   }
-
+  
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   // ========================================================================== //
   //                           Hook for forced buyback                          //
   // ========================================================================== //
@@ -892,6 +893,7 @@ library LibHooksConfig {
   uint256 internal constant ForceBuyBackHook_ExtraData_Length_Offset = 0x0220;
   uint256 internal constant ForceBuyBackHook_ExtraData_TailOffset = 0x0240;
 
+  
   function onForceBuyBack(
     HooksConfig self,
     address lender,
@@ -934,4 +936,5 @@ library LibHooksConfig {
       }
     }
   }
+  */
 }

--- a/test/HooksIntegration.t.sol
+++ b/test/HooksIntegration.t.sol
@@ -554,6 +554,7 @@ contract HooksIntegrationTest is BaseMarketTest {
   //                               onForceBuyBack                               //
   // ========================================================================== //
 
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
   function test_onForceBuyBack(
     address lender,
     // uint112 scaledAmount,
@@ -584,4 +585,5 @@ contract HooksIntegrationTest is BaseMarketTest {
     emit IERC20.Transfer(lender, borrower, 1e18);
     _callMarket(_calldata, '', 'forceBuyBack');
   }
+  */
 }

--- a/test/access/FixedTermLoanHooks.t.sol
+++ b/test/access/FixedTermLoanHooks.t.sol
@@ -1127,6 +1127,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
     hooks.onCloseMarket(state, '');
   }
 
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
   function test_forceBuyBack_ForceBuyBacksDisabled() external {
     
     DeployMarketInputs memory inputs;
@@ -1143,4 +1144,6 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
     MarketState memory state;
     hooks.onForceBuyBack(address(1), 0, state, '');
   }
+  */
+ 
 }

--- a/test/market/WildcatMarket.t.sol
+++ b/test/market/WildcatMarket.t.sol
@@ -710,10 +710,13 @@ contract WildcatMarketTest is BaseMarketTest {
     market.transfer(bob, 0.5e18);
     assertEq(market.balanceOf(bob), 1e18, 'bob.balance');
   }
+  
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
 
   // ========================================================================== //
   //                                Force Buyback                               //
   // ========================================================================== //
+  
   function test_forceBuyBack_NotApprovedBorrower() external {
     vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
     market.forceBuyBack(alice, 0);
@@ -731,13 +734,11 @@ contract WildcatMarketTest is BaseMarketTest {
     market.forceBuyBack(alice, 5e17);
   }
 
-  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
-
+  
   function test_forceBuyBack_NullBuyBackAmount() external asAccount(borrower) {
     vm.expectRevert(IMarketEventsAndErrors.NullBuyBackAmount.selector);
     market.forceBuyBack(alice, 0);
   }
-  */
 
   function test_forceBuyBack_ForceBuyBacksDisabled() external asAccount(borrower) {
     _deposit(alice, 1e18);

--- a/test/shared/mocks/MockHooks.sol
+++ b/test/shared/mocks/MockHooks.sol
@@ -50,12 +50,14 @@ event OnSetProtocolFeeBipsCalled(
   MarketState intermediateState,
   bytes extraData
 );
+/* DEV: event removed as force buyback has been disabled in initial V2 launch
 event OnForceBuyBackCalled(
   address lender,
   uint scaledAmount,
   MarketState intermediateState,
   bytes extraData
 );
+*/
 contract MockHooks is IHooks {
   bytes32 public lastCalldataHash;
   address public deployer;
@@ -275,6 +277,7 @@ contract MockHooks is IHooks {
     emit OnSetProtocolFeeBipsCalled(protocolFeeBips, intermediateState, extraData);
   }
 
+  /* DEV: hook disabled as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
@@ -284,6 +287,7 @@ contract MockHooks is IHooks {
     lastCalldataHash = keccak256(msg.data);
     emit OnForceBuyBackCalled(lender, scaledAmount, intermediateState, extraData);
   }
+  */
 }
 
 contract MockHooksWithConfig is MockHooks {


### PR DESCRIPTION
All the configuration for passing the flag through to the hooks remains, it's just always set as false when actually passed in.