### PR TITLE
feat(morpho vault adapter) : first draft vault adapter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "lib/ethereum-access-token"]
 	path = lib/ethereum-access-token
 	url = https://github.com/wildcat-finance/ethereum-access-token
+[submodule "lib/vault-v2"]
+	path = lib/vault-v2
+	url = https://github.com/morpho-org/vault-v2.git

--- a/integrations/morpho/WildcatMarketV2Adapter.sol
+++ b/integrations/morpho/WildcatMarketV2Adapter.sol
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: TODO
+pragma solidity 0.8.28;
+
+import {IVaultV2} from "lib/vault-v2/src/interfaces/IVaultV2.sol";
+import {IAdapter} from "lib/vault-v2/src/interfaces/IAdapter.sol";
+import {IERC20} from "lib/vault-v2/src/interfaces/IERC20.sol";
+import {LibERC20} from "src/libraries/LibERC20.sol";
+
+import {IWildcatMarket} from "./interfaces/IWildcatMarket.sol";
+import {IWildcatMarketV2Adapter} from "./interfaces/IWildcatMarketV2Adapter.sol";
+
+/**
+ * @notice Adapter for allocating morpho-VaultV2 funds into a wildcat market.
+ * @dev Withdrawals in wildcat are async
+ * @dev curators must call queueAdapterWithdrawal before deallocating
+ *        - On allocate: it deposits the adapter's asset balance into the market.
+ *        - On deallocate: attempts to execute withdrawal of matured batches
+ * 			owed to this adapter, succeeding if there is sufficient liquidity
+ */
+contract WildcatMarketV2Adapter is IWildcatMarketV2Adapter {
+	using LibERC20 for address;
+	// ===================================================================== //
+	//                               Immutables                              //
+	// ===================================================================== //
+
+	address public immutable factory; // if we actually care for a factory
+	address public immutable parentVault;
+	address public immutable market;
+	address public immutable asset;
+	bytes32 public immutable adapterId;
+
+	// ===================================================================== //
+	//                                 Storage                               //
+	// ===================================================================== //
+
+	address public skimRecipient;
+	mapping(uint32 => uint256) public pendingWithdrawals; // expiry => amount queued by this adapter
+	uint256 public totalPendingWithdrawals; // total amount queued
+	uint32[] internal trackedWithdrawalExpiries; // unique expiries the adapter has queued against
+	mapping(uint32 => uint256) internal trackedExpiryIndexPlusOne; // index 1based
+
+	// ===================================================================== //
+	//                               Constructor                             //
+	// ===================================================================== //
+
+	constructor(address _parentVault, address _market) {
+		factory = msg.sender;
+		parentVault = _parentVault;
+		market = _market;
+
+		address _asset = IVaultV2(_parentVault).asset();
+		require(_asset == IWildcatMarket(_market).asset(), AssetMismatch());
+		asset = _asset;
+
+		adapterId = keccak256(abi.encode("this", address(this)));
+
+		// approvals: vault pulls on deallocate, market pulls on deposit
+		// TODO: do we want to set max's?
+		_safeApprove(asset, parentVault, type(uint256).max);
+		_safeApprove(asset, market, type(uint256).max);
+	}
+
+	/**
+	 * @notice Set the recipient for skimmed tokens.
+	 * @dev Only callable by the vault owner.
+	 * @param newSkimRecipient Address that will receive skimmed tokens.
+	 */
+	function setSkimRecipient(address newSkimRecipient) external {
+		if (msg.sender != IVaultV2(parentVault).owner()) revert NotAuthorized();
+		skimRecipient = newSkimRecipient;
+		emit SetSkimRecipient(newSkimRecipient);
+	}
+
+	/**
+	 * @notice Skim arbitrary ERC20 held by the adapter (e.g., rewards) to `skimRecipient`.
+	 * @dev Reverts if `token` is the Wildcat market token itself. Only the `skimRecipient` may call.
+	 * @param token The ERC20 address to skim.
+	 */
+	function skim(address token) external {
+		if (msg.sender != skimRecipient) revert NotAuthorized();
+		if (token == market) revert CannotSkimWildcatMarketTokens(); // MOOSE: do we also want to prevent underlying?
+		uint256 balance = token.balanceOf(address(this));
+		token.safeTransfer(skimRecipient, balance);
+		emit Skim(token, balance);
+	}
+
+	/**
+	 * @notice Allocate assets into the market.
+	 * @dev Only callable by the parent vault. `data` must be empty. If `assets > 0`,
+	 *      deposits up to `assets` from the adapter's asset balance to the market.
+	 * @param data Unused; must be empty (0x).
+	 * @param assets Amount to allocate.
+	 * @return ids The single adapter id used by this position.
+	 * @return change The signed change in allocation.
+	 */
+	function allocate(bytes memory data, uint256 assets, bytes4, address)
+		external
+		returns (bytes32[] memory, int256)
+	{
+		if (data.length != 0) revert InvalidData();
+		if (msg.sender != parentVault) revert NotAuthorized();
+
+		if (assets > 0) {
+			IWildcatMarket(market).deposit(assets);
+		}
+
+		uint256 oldAllocation = allocation();
+		uint256 newAllocation = IWildcatMarket(market).balanceOf(address(this));
+		int256 change = int256(newAllocation) - int256(oldAllocation);
+		return (ids(), change);
+	}
+
+	/**
+	 * @notice Deallocate assets from the adapter back to the parent vault.
+	 * @dev
+	 * - Only callable by the parent vault.
+	 * - `data` must be empty (0x); no custom logic supported.
+	 * - Attempts to realize up to 8 matured withdrawal batches owed to this adapter before deallocation.
+	 * - Ensures the adapter has enough asset liquidity for the vault to pull the requested amount.
+	 * - Reverts if insufficient immediate liquidity is available.
+	 * @dev - the VaultV2 will pull the EXACT amount of `assets` from the adapter right after this call.
+	 * 
+	 * @param data Unused parameter; must be empty.
+	 * @param assets Amount of assets to deallocate (transfer back to the vault).
+	 * @return ids The single adapter id used by this position.
+	 * @return change The signed change in allocation (new allocation minus old allocation).
+	 */
+	function deallocate(bytes memory data, uint256 assets, bytes4, address)
+		external
+		returns (bytes32[] memory, int256)
+	{
+		if (data.length != 0) revert InvalidData();
+		if (msg.sender != parentVault) revert NotAuthorized();
+
+		if (assets > 0) {
+			// Attempt to realize up to 8 matured withdrawal batches owed to this adapter.
+			// This is a arbitrary number of batches to call to increase available liquidity before deallocation.
+			_realizeClaimable(8);
+
+			// Check if the adapter has enough asset balance to fulfill the deallocation.
+			uint256 available = asset.balanceOf(address(this));
+			if (available < assets) revert InsufficientImmediateLiquidity();
+		}
+
+		uint256 oldAllocation = allocation();
+		uint256 newAllocation = IWildcatMarket(market).balanceOf(address(this));
+		int256 change = int256(newAllocation) - int256(oldAllocation);
+
+		return (ids(), change);
+	}
+
+	/**
+	 * @notice Current assets as seen by the adapter (0 if vault allocation is zero).
+	 */
+	function realAssets() external view returns (uint256) {
+		if (allocation() == 0) return 0;
+		return IWildcatMarket(market).balanceOf(address(this)) + asset.balanceOf(address(this));
+	}
+
+	// ===================================================================== //
+	//                                Views                                   //
+	// ===================================================================== //
+
+	/**
+	 * @notice Adapter id this position uses (assumed we only want one? )
+	 */
+	function ids() public view returns (bytes32[] memory) {
+		bytes32[] memory ids_ = new bytes32[](1);
+		ids_[0] = adapterId;
+		return ids_;
+	}
+
+	/**
+	 * @notice Current allocation recorded by the vault for this adapter id.
+	 */
+	function allocation() public view returns (uint256) {
+		return IVaultV2(parentVault).allocation(adapterId);
+	}
+
+	// ===================================================================== //
+	//                               Internals                               //
+	// ===================================================================== //
+
+	/**
+	/*
+	TL;DR: Withdrawals are batched by "expiry" timestamps, and only become realizable once
+	they mature. To avoid scanning arbitrary timestamps and to bound gas, we keep an
+	indexable set of expiries that currently have nonzero pending amounts. This lets us:
+	- process at most `maxBatches` matured buckets per call,
+	- remain best-effort and non-reverting via try/catch when querying availability,
+	- reconcile both per-expiry and global pending debt as amounts are realized, and
+	- remove empty buckets in O(1) using swap-and-pop with a 1-based index map.
+	We iterate the tracked array in reverse so removals don’t invalidate yet-to-be-visited
+	indices.
+	*/
+
+	/**
+	 * @notice Realize up to `maxBatches` matured withdrawal batches owed to this adapter.
+	 * @dev Processes up to `maxBatches` matured batches. errors querying batch
+	 *      availability are ignored to keep this non-reverting.
+	 *      For each matured batch, attempts to execute withdrawal and update tracking.
+	 * @param maxBatches Maximum number of batches to try process
+	 */
+	function _realizeClaimable(uint256 maxBatches) internal {
+		if (maxBatches == 0) return;
+		uint32[] storage expiries = trackedWithdrawalExpiries;
+		uint256 len = expiries.length;
+		if (len == 0) return;
+		uint256 processed;
+		address self = address(this);
+		IWildcatMarket marketContract = IWildcatMarket(market);
+		for (uint256 i = len; i > 0 && processed < maxBatches; ) {
+			unchecked { i--; }
+			uint32 expiry = expiries[i];
+			if (expiry >= block.timestamp) continue;
+			processed++;
+			uint256 available;
+			try marketContract.getAvailableWithdrawalAmount(self, expiry) returns (uint256 amt) {
+				available = amt;
+			} catch {
+				continue;
+			}
+			if (available > 0) {
+				uint256 withdrawn = marketContract.executeWithdrawal(self, expiry);
+				_updatePendingAfterWithdrawal(expiry, withdrawn);
+			}
+			if (pendingWithdrawals[expiry] == 0) {
+				_untrackExpiryAt(i, expiry);
+			}
+		}
+	}
+
+	function _updatePendingAfterWithdrawal(uint32 expiry, uint256 withdrawn) internal {
+		if (withdrawn == 0) return;
+		uint256 pending = pendingWithdrawals[expiry];
+		if (pending >= withdrawn) {
+			pendingWithdrawals[expiry] = pending - withdrawn;
+			totalPendingWithdrawals = totalPendingWithdrawals > withdrawn ?
+				totalPendingWithdrawals - withdrawn : 0;
+			if (pending == withdrawn) {
+				delete pendingWithdrawals[expiry];
+			}
+		} else {
+			// More was realized than originally tracked (interest/rounding). Zero out tracking.
+			totalPendingWithdrawals = totalPendingWithdrawals > pending ?
+				totalPendingWithdrawals - pending : 0;
+			delete pendingWithdrawals[expiry];
+		}
+	}
+
+	function _trackExpiry(uint32 expiry) internal {
+		if (expiry == 0) return;
+		if (trackedExpiryIndexPlusOne[expiry] != 0) return;
+		trackedWithdrawalExpiries.push(expiry);
+		trackedExpiryIndexPlusOne[expiry] = trackedWithdrawalExpiries.length;
+	}
+
+	function _untrackExpiryAt(uint256 index, uint32 expiry) internal {
+		uint256 arrayLength = trackedWithdrawalExpiries.length;
+		if (index >= arrayLength) return;
+		uint32 lastExpiry = trackedWithdrawalExpiries[arrayLength - 1];
+		if (index != arrayLength - 1) {
+			trackedWithdrawalExpiries[index] = lastExpiry;
+			trackedExpiryIndexPlusOne[lastExpiry] = index + 1;
+		}
+		trackedWithdrawalExpiries.pop();
+		delete trackedExpiryIndexPlusOne[expiry];
+	}
+
+	function _recordPending(uint32 expiry, uint256 amount) internal {
+		if (expiry == 0 || amount == 0) return;
+		pendingWithdrawals[expiry] += amount;
+		totalPendingWithdrawals += amount;
+		_trackExpiry(expiry);
+	}
+
+	function _safeApprove(address token, address spender, uint256 amount) internal {
+		// reset to zero first for usdt-like tokens
+		(bool s1, ) = token.call(abi.encodeWithSelector(IERC20.approve.selector, spender, 0));
+		require(s1, "APPROVE_RESET_FAILED");
+		(bool s2, ) = token.call(abi.encodeWithSelector(IERC20.approve.selector, spender, amount));
+		require(s2, "APPROVE_FAILED");
+	}
+
+
+
+    // ===================================================================== //
+    //                             helpers                                   //
+    // ===================================================================== //
+
+	/**
+	 * @notice Queue a withdrawal for `amount` normalized assets held by this adapter.
+	 * @dev Only callable by the vault owner or an authorized allocator. `amount` is in
+	 *      underlying (normalized) units as expected by the market.
+	 */
+	function queueAdapterWithdrawal(uint256 amount) external {
+		address _parent = parentVault;
+		if (msg.sender != IVaultV2(_parent).owner() && !IVaultV2(_parent).isAllocator(msg.sender)) revert NotAuthorized();
+		uint32 expiry = IWildcatMarket(market).queueWithdrawal(amount);
+		_recordPending(expiry, amount);
+	}
+
+	/**
+	 * @notice Realize up to `maxBatches` matured unpaid withdrawals owed to this adapter.
+	 */
+	function realizeClaimable(uint256 maxBatches) external {
+		_realizeClaimable(maxBatches);
+	}
+
+	/**
+	 * @notice Get available liquidity withdrawable now (balanceOf + matured claimable).
+	 * @dev helper for allocators to check synchronous liquidity
+	 */
+	function getAvailableLiquidity() external view returns (uint256 available) {
+		available = asset.balanceOf(address(this));
+
+		uint32[] storage expiries = trackedWithdrawalExpiries;
+		IWildcatMarket marketContract = IWildcatMarket(market);
+		address self = address(this);
+		for (uint256 i = 0; i < expiries.length; i++) {
+			uint32 expiry = expiries[i];
+			if (expiry >= block.timestamp) continue;
+			try marketContract.getAvailableWithdrawalAmount(self, expiry) returns (uint256 amt) {
+				available += amt;
+			} catch {}
+		}
+		return available;
+	}
+
+	/**
+	 * @notice Check if `amount` can be withdrawn now.
+	 * @dev helper for the vault to check whether a synchronous withdrawal will succeed.
+	 */
+	function canWithdrawSync(uint256 amount) external view returns (bool) {
+		return this.getAvailableLiquidity() >= amount;
+	}
+}

--- a/integrations/morpho/WildcatMarketV2AdapterFactory.sol
+++ b/integrations/morpho/WildcatMarketV2AdapterFactory.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: TODO
+pragma solidity 0.8.28;
+
+import {WildcatMarketV2Adapter} from "./WildcatMarketV2Adapter.sol";
+import {IWildcatMarketV2AdapterFactory} from "./interfaces/IWildcatMarketV2AdapterFactory.sol";
+
+/**
+ * @notice factory that deploys one adapter per (vault, market) pair.
+ * TODO: maybe remove if we dont need factory
+ */
+contract WildcatMarketV2AdapterFactory is IWildcatMarketV2AdapterFactory {
+
+	mapping(address parentVault => mapping(address market => address)) public wildcatMarketV2Adapter;
+	mapping(address account => bool) public isWildcatMarketV2Adapter;
+
+	function createWildcatMarketV2Adapter(address parentVault, address market)
+		external
+		returns (address adapter)
+	{
+		address _adapter = address(new WildcatMarketV2Adapter{salt: bytes32(0)}(parentVault, market));
+		wildcatMarketV2Adapter[parentVault][market] = _adapter;
+		isWildcatMarketV2Adapter[_adapter] = true;
+		emit CreateWildcatMarketV2Adapter(parentVault, market, _adapter);
+		return _adapter;
+	}
+}

--- a/integrations/morpho/interfaces/IWildcatMarket.sol
+++ b/integrations/morpho/interfaces/IWildcatMarket.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: TODO
+pragma solidity >=0.8.20;
+
+/**
+ * @notice minimal Wildcat market interface used by the Morpho adapter.
+ */
+interface IWildcatMarket {
+
+    /// @notice Underlying asset of the market
+    function asset() external view returns (address);
+
+    /// @notice Deposit exactly `amount` underlying asset
+    function deposit(uint256 amount) external;
+
+    /// @notice Normalized balance of `account`
+    function balanceOf(address account) external view returns (uint256);
+
+    /// @notice Queue a withdrawal of `amount` normalized assets
+    function queueWithdrawal(uint256 amount) external returns (uint32 expiry);
+
+    /// @notice Execute a matured withdrawal for `account` and `expiry`
+    function executeWithdrawal(address account, uint32 expiry) external returns (uint256);
+
+    /// @notice Expiries of every unpaid withdrawal batch
+    function getUnpaidBatchExpiries() external view returns (uint32[] memory);
+
+    /// @notice Amount currently available to withdraw immediately for `account` and `expiry`
+    function getAvailableWithdrawalAmount(address account, uint32 expiry) external view returns (uint256);
+}

--- a/integrations/morpho/interfaces/IWildcatMarketV2Adapter.sol
+++ b/integrations/morpho/interfaces/IWildcatMarketV2Adapter.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: TODO
+pragma solidity >=0.5.0;
+
+import {IAdapter} from "lib/vault-v2/src/interfaces/IAdapter.sol";
+
+/**
+ * @notice Wildcat market adapter interface used by Morpho VaultV2
+ * @dev mirrors Morpho V1 adapter with some helpers for integratoors
+ */
+interface IWildcatMarketV2Adapter is IAdapter {
+
+    event SetSkimRecipient(address indexed newSkimRecipient);
+    event Skim(address indexed token, uint256 assets);
+
+    error AssetMismatch();
+    error CannotSkimWildcatMarketTokens();
+    error InvalidData();
+    error NotAuthorized();
+    error InsufficientImmediateLiquidity();
+
+    /// @notice Factory that created this adapter.
+    function factory() external view returns (address);
+
+    /// @notice Parent vault v2 address.
+    function parentVault() external view returns (address);
+
+    /// @notice Wildcat market v2 address.
+    function market() external view returns (address);
+
+    /// @notice Unique adapter id used by the vault.
+    function adapterId() external view returns (bytes32);
+
+    /// @notice Recipient of skimmed tokens.
+    function skimRecipient() external view returns (address);
+
+    /// @notice Current vault-recorded allocation.
+    function allocation() external view returns (uint256);
+
+    /// @notice Ids array (single element).
+    function ids() external view returns (bytes32[] memory);
+
+    /// @notice Set the skim recipient (vault owner only).
+    function setSkimRecipient(address newSkimRecipient) external;
+
+    /// @notice Skim arbitrary ERC20 (not the market token).
+    function skim(address token) external;
+
+    // helpers
+
+    /// @notice Queue a withdrawal for `amount` normalized assets held by this adapter.
+    function queueAdapterWithdrawal(uint256 amount) external;
+
+    /// @notice Realize up to `maxBatches` matured unpaid withdrawals owed to this adapter.
+    function realizeClaimable(uint256 maxBatches) external;
+
+    /// @notice Get available liquidity withdrawable now (adapter balance plus matured claimable).
+    function getAvailableLiquidity() external view returns (uint256);
+
+    /// @notice Check if `amount` can be withdrawn synchronously now.
+    function canWithdrawSync(uint256 amount) external view returns (bool);
+}

--- a/integrations/morpho/interfaces/IWildcatMarketV2AdapterFactory.sol
+++ b/integrations/morpho/interfaces/IWildcatMarketV2AdapterFactory.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: TODO
+pragma solidity >=0.5.0;
+
+interface IWildcatMarketV2AdapterFactory {
+
+    event CreateWildcatMarketV2Adapter(
+        address indexed parentVault, address indexed market, address indexed wildcatMarketV2Adapter
+    );
+
+    /// @notice Get the adapter address for a given (vault, market) pair
+    function wildcatMarketV2Adapter(address parentVault, address market) external view returns (address);
+
+    /// @notice Check if an address is a deployed adapter from this factory
+    function isWildcatMarketV2Adapter(address account) external view returns (bool);
+
+    /// @notice Deploy a new adapter for a parent vault and market
+    function createWildcatMarketV2Adapter(address parentVault, address market)
+        external
+        returns (address wildcatMarketV2Adapter);
+}

--- a/test/integrations/morpho/WildcatMarketV2Adapter.t.sol
+++ b/test/integrations/morpho/WildcatMarketV2Adapter.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity 0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {IVaultV2} from "lib/vault-v2/src/interfaces/IVaultV2.sol";
+import {IERC20} from "lib/vault-v2/src/interfaces/IERC20.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+
+import {IWildcatMarket} from "../../../integrations/morpho/interfaces/IWildcatMarket.sol";
+import {WildcatMarketV2Adapter} from "../../../integrations/morpho/WildcatMarketV2Adapter.sol";
+import {IWildcatMarketV2Adapter} from "../../../integrations/morpho/interfaces/IWildcatMarketV2Adapter.sol";
+
+
+contract MockWildcatMarket is IWildcatMarket {
+    address public immutable override asset;
+    mapping(address => uint256) internal _balances;
+    uint32[] internal _unpaid;
+    mapping(uint32 => mapping(address => uint256)) internal _owed; // expiry => account => amount
+    uint32 public lastExpiry;
+
+    constructor(address _asset) { asset = _asset; }
+
+    function deposit(uint256 amount) external override {
+        IERC20(asset).transferFrom(msg.sender, address(this), amount);
+        _balances[msg.sender] += amount;
+    }
+    function balanceOf(address account) external view override returns (uint256) { return _balances[account]; }
+    function queueWithdrawal(uint256 amount) external override returns (uint32 expiry) {
+        if (amount == 0) return 0;
+        // Simulate burn to pending
+        require(_balances[msg.sender] >= amount, "insufficient");
+        _balances[msg.sender] -= amount;
+        expiry = uint32(block.timestamp + 1); // expires in the near future
+        lastExpiry = expiry;
+        _unpaid.push(expiry);
+        _owed[expiry][msg.sender] += amount;
+        return expiry;
+    }
+    function executeWithdrawal(address account, uint32 expiry) external override returns (uint256) {
+        uint256 amt = _owed[expiry][account];
+        if (amt == 0) return 0;
+        _owed[expiry][account] = 0;
+        IERC20(asset).transfer(account, amt);
+        return amt;
+    }
+    function getUnpaidBatchExpiries() external view override returns (uint32[] memory) { return _unpaid; }
+    function getAvailableWithdrawalAmount(address account, uint32 expiry) external view override returns (uint256) { return _owed[expiry][account]; }
+
+    function clearUnpaid() external { delete _unpaid; }
+}
+
+contract VaultStub {
+    address public immutable asset;
+    address public immutable owner;
+    mapping(bytes32=>uint256) public allocation;
+    constructor(address _asset, address _owner){ asset=_asset; owner=_owner; }
+}
+
+contract WildcatMarketV2AdapterTest is Test {
+    MockERC20 internal asset;
+    address internal vault; // stubbed addy
+    MockWildcatMarket internal market;
+    WildcatMarketV2Adapter internal adapter;
+    address internal vaultOwner = address(0xBEEF);
+
+    function setUp() public {
+        asset = new MockERC20("Mock", "MOCK", 18);
+    market = new MockWildcatMarket(address(asset));
+
+    // Deploy a minimal Vault stub with the same asset and an owner.
+    vault = address(new VaultStub(address(asset), vaultOwner));
+
+        vm.startPrank(address(this));
+    adapter = new WildcatMarketV2Adapter(vault, address(market));
+        vm.stopPrank();
+
+        // fund the caller and approve adapter to pull during allocate via VaultV2.transfer to adapter
+        asset.mint(address(adapter), 0); // ensure zero start
+    }
+
+    function test_allocate_noop_when_zero_assets() public {
+        vm.prank(vault);
+        (bytes32[] memory ids, int256 change) = adapter.allocate("", 0, bytes4(0), address(this));
+        assertEq(ids.length, 1);
+        assertEq(change, int256(0));
+    }
+
+    function test_skim_flow() public {
+        
+        vm.prank(vaultOwner);
+        adapter.setSkimRecipient(address(0xCAFE));
+
+       
+        MockERC20 reward = new MockERC20("randomtoken", "RND", 18);
+        reward.mint(address(adapter), 123e6);
+
+        vm.prank(address(0xCAFE));
+        adapter.skim(address(reward));
+        assertEq(reward.balanceOf(address(0xCAFE)), 123e6);
+    }
+
+    function test_skim_rejects_market_address() public {
+        vm.prank(vaultOwner);
+        adapter.setSkimRecipient(address(this));
+        vm.expectRevert(IWildcatMarketV2Adapter.CannotSkimWildcatMarketTokens.selector);
+        adapter.skim(address(market));
+    }
+
+    function test_deallocate_reverts_without_liquidity() public {
+        vm.expectRevert(IWildcatMarketV2Adapter.InsufficientImmediateLiquidity.selector);
+        vm.prank(vault);
+        adapter.deallocate("", 1, bytes4(0), address(this));
+    }
+
+    function test_allocate_deposits_and_reports_change() public {
+        // mint assets to adapter so it can deposit into market during allocate
+        asset.mint(address(adapter), 1_000e18);
+        vm.prank(vault);
+        (bytes32[] memory ids, int256 change) = adapter.allocate("", 1_000e18, bytes4(0), address(this));
+        assertEq(ids.length, 1);
+        assertEq(change, int256(1_000e18));
+        assertEq(market.balanceOf(address(adapter)), 1_000e18);
+    }
+
+    function test_prepare_realize_then_deallocate() public {
+        // start with market balance on adapter
+        asset.mint(address(adapter), 1_000e18);
+        vm.prank(vault);
+        adapter.allocate("", 1_000e18, bytes4(0), address(this));
+        assertEq(market.balanceOf(address(adapter)), 1_000e18);
+
+        // queue a withdrawal for 600
+        vm.prank(vaultOwner);
+        adapter.queueAdapterWithdrawal(600e18);
+        uint32 queuedExpiry = market.lastExpiry();
+        assertTrue(queuedExpiry != 0);
+        assertEq(adapter.pendingWithdrawals(queuedExpiry), 600e18);
+        assertEq(adapter.totalPendingWithdrawals(), 600e18);
+
+        // advance beyond expiry so withdrawals are claimable
+        vm.warp(uint256(queuedExpiry) + 2);
+
+        assertEq(asset.balanceOf(address(adapter)), 0);
+
+        market.clearUnpaid();
+
+        assertEq(adapter.getAvailableLiquidity(), 600e18);
+
+        adapter.realizeClaimable(4);
+        assertEq(asset.balanceOf(address(adapter)), 600e18);
+        assertEq(adapter.totalPendingWithdrawals(), 0);
+        assertEq(adapter.getAvailableLiquidity(), 600e18);
+
+        // deallocate 600 should succeed 
+        vm.prank(vault);
+    (bytes32[] memory ids, int256 change) = adapter.deallocate("", 600e18, bytes4(0), address(this));
+        assertEq(ids.length, 1);
+
+    assertEq(change, int256(400e18));
+    }
+
+    function test_multiple_queue_updates_tracking() public {
+        asset.mint(address(adapter), 1_000e18);
+        vm.prank(vault);
+        adapter.allocate("", 1_000e18, bytes4(0), address(this));
+
+        vm.prank(vaultOwner);
+        adapter.queueAdapterWithdrawal(250e18);
+        uint32 expiry = market.lastExpiry();
+        assertTrue(expiry != 0);
+        assertEq(adapter.pendingWithdrawals(expiry), 250e18);
+        assertEq(adapter.totalPendingWithdrawals(), 250e18);
+
+        vm.prank(vaultOwner);
+        adapter.queueAdapterWithdrawal(350e18);
+        assertEq(market.lastExpiry(), expiry);
+        assertEq(adapter.pendingWithdrawals(expiry), 600e18);
+        assertEq(adapter.totalPendingWithdrawals(), 600e18);
+
+        market.clearUnpaid();
+        vm.warp(uint256(expiry) + 2);
+
+        adapter.realizeClaimable(5);
+        assertEq(adapter.totalPendingWithdrawals(), 0);
+        assertEq(adapter.pendingWithdrawals(expiry), 0);
+    }
+}


### PR DESCRIPTION
Adapter for [morpho's VaultV2 ](https://github.com/morpho-org/vault-v2)

Morpho's guidance was _"Ok, very clear. Then in that case you should use vault v2 with a custom adapter that takes into account the asynchronicity. You can take inspiration from the [Vaultv1 adapter](https://github.com/morpho-org/vault-v2/blob/main/src/adapters/MorphoVaultV1Adapter.sol) "_

### TLDR
- VaultV2's introduce _adapters_ which are a wrapper that allows a vault to interact with other protocols (wildcat)
- Need special adapter because vaults `allocate` and `deallocate` need to be synchronous. Our withdraw process is asyncrhonous.
- This adapter exposes some helpers for a curator to initiate a withdrawal and then `deallocate` performs the execute which claims.

#### code
- `WildcatMarketV2Adapter` is the main file - contains the logic for vault <-> wildcat market interactions
- various interfaces
- some tests which still being expanded

#### explanation

Adapter deposits funds into wildcat markets on `allocate()` calls and attempts to pull funds on `deallocate()`. Since our withdrawals need to queue and mature, the adapter tracks pending batches to keep expiries. When attempting to `deallocate` we try and realise any matured expiries and if there isnt enough liquidity for the deallocation request it fails.

Contract maintains an indexed list of expiries with pending withdrawals and mutates as realised. 

### Tricky parts / confusions / please read dillon / laurence
- The Vault will instantly attempt to withdraw **exactly** the amount that `deallocate` is called with. This is only important for us since we can have scenarios where partial amounts are paid and the adapter/vault must revert or deallocate the exact amount.
- No forced de-allocation. the spec does include that force-deallocation should be included but we cant do that.
- I've left all licensing as `TODO` because nfi and dont want tim clancy on my back
- theres a magic number being used in `deallocate` - `_realizeClaimable(8);` this is just an arbitrary depth of batches to try and resolve on a deallocate call. if theres a better constant to use here LMK. can also be side-stepped with the function that allows you to input batch num though
- I included an adaptor factory because the morpho example had one. if we don't need it we can remove
- approvals are set to max so that the vault can deallocate and allocate at will - seems intentional by design but just double check no footgun.



