### PR TITLE
Deposit hooks

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,40 @@
+# Role Providers
+
+This document captures current provider choices and future candidates.
+
+## Current
+- ERC721RoleProvider: gates on `balanceOf(lender) > 0` for a configured ERC721.
+  - `skipInterfaceCheck` can be used for ERC165-less collections.
+- ERC5192/5484: ERC721-compatible for balance-based gating. "Locked/soulbound" is token/contract-specific and not enforced by default.
+- ERC1155RoleProvider: gates on `balanceOf(lender, tokenId) > 0` for a configured ERC1155.
+  - `skipInterfaceCheck` can be used for ERC165-less collections.
+
+## TODO
+### ERC4907 (rentable ERC721)
+- Motivation: allow renters via `userOf(tokenId)` rather than owners.
+- TokenId-specific; options:
+  - Immutable tokenId in provider constructor.
+  - Push-style provider where `hooksData` includes tokenId.
+  - Allowlist or Merkle root of tokenIds.
+- Credential check: `userOf(tokenId) == lender` and `userExpires(tokenId)` is 0 or in the future.
+- TTL: keep at 0/short since AccessControlHooks caches "granted at", not expiry.
+
+### ERC6551 (token-bound accounts)
+- Motivation: allow token-bound accounts (TBA) as lenders.
+- Two models:
+  - Lender is the TBA; verify `IERC6551Account(lender).token()` and/or `owner()`.
+  - Lender is EOA; compute expected TBA from registry + implementation + tokenId.
+- Requires tokenId specificity unless gating on "any token in collection".
+- Provider config likely needs registry + implementation + token contract (+ optional salt).
+- TTL: keep at 0/short because ownership changes on transfer.
+
+### ERC5192 / ERC5484 (soulbound)
+- Base gating is the same as ERC721.
+- Optional checks if we want "must be locked":
+  - `locked(tokenId)` for ERC5192.
+  - burn/issuer rules for ERC5484.
+- TokenId-specific.
+
+## Notes
+- ERC721A/721C are implementation variants; ERC721RoleProvider already works.
+- CryptoPunks-style tokens may not implement ERC165; use `skipInterfaceCheck`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -7,6 +7,9 @@ This document captures current provider choices and future candidates.
   - `skipInterfaceCheck` can be used for ERC165-less collections.
 - ERC20RoleProvider: gates on `balanceOf(lender) >= minBalance` for a configured ERC20.
   - `minBalance` is in base units of the ERC20.
+- ERC4626AssetsRoleProvider: gates on `convertToAssets(balanceOf(lender)) >= minAssets`.
+  - `minAssets` is in base units of the ERC4626 underlying asset.
+  - For share-based gating, use `ERC20RoleProvider` against the vault share token instead.
 - ERC5192RoleProvider: validates ownership of a specific tokenId via hooksData.
   - `requireLocked` enforces `locked(tokenId)` when true.
   - `hooksData` encoding: `abi.encodePacked(provider, abi.encode(tokenId))`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -5,7 +5,14 @@ This document captures current provider choices and future candidates.
 ## Current
 - ERC721RoleProvider: gates on `balanceOf(lender) > 0` for a configured ERC721.
   - `skipInterfaceCheck` can be used for ERC165-less collections.
-- ERC5192/5484: ERC721-compatible for balance-based gating. "Locked/soulbound" is token/contract-specific and not enforced by default.
+- ERC5192RoleProvider: validates ownership of a specific tokenId via hooksData.
+  - `requireLocked` enforces `locked(tokenId)` when true.
+  - `hooksData` encoding: `abi.encodePacked(provider, abi.encode(tokenId))`.
+  - `skipInterfaceCheck` bypasses ERC165.
+- ERC5484RoleProvider: validates ownership of a specific tokenId via hooksData.
+  - `allowedBurnAuthMask` selects permitted burnAuth values (bit 0: IssuerOnly, 1: OwnerOnly, 2: Both, 3: Neither).
+  - `hooksData` encoding: `abi.encodePacked(provider, abi.encode(tokenId))`.
+  - `skipInterfaceCheck` bypasses ERC165.
 - ERC1155RoleProvider: gates on `balanceOf(lender, tokenId) > 0` for a configured ERC1155.
   - `skipInterfaceCheck` can be used for ERC165-less collections.
 - MerkleRoleProvider: validates `keccak256(abi.encode(lender))` using a sorted-pair proof from `hooksData`.
@@ -32,12 +39,9 @@ This document captures current provider choices and future candidates.
 - Provider config likely needs registry + implementation + token contract (+ optional salt).
 - TTL: keep at 0/short because ownership changes on transfer.
 
-### ERC5192 / ERC5484 (soulbound)
-- Base gating is the same as ERC721.
-- Optional checks if we want "must be locked":
-  - `locked(tokenId)` for ERC5192.
-  - burn/issuer rules for ERC5484.
-- TokenId-specific.
+### ERC5484 stricter enforcement
+- Optional checks if we want burn/issuer rules enforced for a specific tokenId.
+- TokenId-specific provider needed for these checks.
 
 ## Notes
 - ERC721A/721C are implementation variants; ERC721RoleProvider already works.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -5,6 +5,8 @@ This document captures current provider choices and future candidates.
 ## Current
 - ERC721RoleProvider: gates on `balanceOf(lender) > 0` for a configured ERC721.
   - `skipInterfaceCheck` can be used for ERC165-less collections.
+- ERC20RoleProvider: gates on `balanceOf(lender) >= minBalance` for a configured ERC20.
+  - `minBalance` is in base units of the ERC20.
 - ERC5192RoleProvider: validates ownership of a specific tokenId via hooksData.
   - `requireLocked` enforces `locked(tokenId)` when true.
   - `hooksData` encoding: `abi.encodePacked(provider, abi.encode(tokenId))`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,6 +10,8 @@ This document captures current provider choices and future candidates.
   - `skipInterfaceCheck` can be used for ERC165-less collections.
 - MerkleRoleProvider: validates `keccak256(abi.encode(lender))` using a sorted-pair proof from `hooksData`.
   - Root is mutable via `updateRoot` for the configured admin.
+  - `hooksData` encoding: `abi.encodePacked(provider, abi.encode(bytes32[] proof))`.
+  - `isMember(account, proof)` mirrors on-chain verification against the current root.
 
 ## TODO
 ### ERC4907 (rentable ERC721)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,6 +8,8 @@ This document captures current provider choices and future candidates.
 - ERC5192/5484: ERC721-compatible for balance-based gating. "Locked/soulbound" is token/contract-specific and not enforced by default.
 - ERC1155RoleProvider: gates on `balanceOf(lender, tokenId) > 0` for a configured ERC1155.
   - `skipInterfaceCheck` can be used for ERC165-less collections.
+- MerkleRoleProvider: validates `keccak256(abi.encode(lender))` using a sorted-pair proof from `hooksData`.
+  - Root is mutable via `updateRoot` for the configured admin.
 
 ## TODO
 ### ERC4907 (rentable ERC721)

--- a/foundry.toml
+++ b/foundry.toml
@@ -61,3 +61,22 @@ call_override = false
 dictionary_weight = 80
 include_storage = true
 include_push_bytes = true
+
+[lint]
+lint_on_build = false
+exclude_lints = [
+  "unaliased-plain-import",
+  "unsafe-cheatcode",
+  "unused-import",
+  "screaming-snake-case-const",
+  "mixed-case-variable",
+  "mixed-case-function",
+  "screaming-snake-case-immutable",
+  "unwrapped-modifier-logic",
+  "erc20-unchecked-transfer",
+  "unsafe-typecast",
+  "named-struct-fields",
+  "unchecked-call",
+  "asm-keccak256",
+  "pascal-case-struct",
+]

--- a/src/access/AccessControlHooks.sol
+++ b/src/access/AccessControlHooks.sol
@@ -210,7 +210,8 @@ contract AccessControlHooks is MarketConstraintHooks {
       depositRequiresAccess: marketHooksConfig.useOnDeposit(),
       minimumDeposit: _readUint128Cd(hooksData),
       transfersDisabled: _readBoolCd(hooksData, 0x20),
-      allowForceBuyBacks: _readBoolCd(hooksData, 0x40)
+      // DEV: intentionally disabled for initial V2 launch
+      allowForceBuyBacks: false // _readBoolCd(hooksData, 0x40)
     });
 
     if (hookedMarket.minimumDeposit > 0) {

--- a/src/access/AccessControlHooks.sol
+++ b/src/access/AccessControlHooks.sol
@@ -993,6 +993,7 @@ contract AccessControlHooks is MarketConstraintHooks {
     bytes calldata /* extraData */
   ) external override {}
 
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
@@ -1015,4 +1016,5 @@ contract AccessControlHooks is MarketConstraintHooks {
       );
     }
   }
+  */
 }

--- a/src/access/FixedTermLoanHooks.sol
+++ b/src/access/FixedTermLoanHooks.sol
@@ -1069,6 +1069,7 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
     bytes calldata /* extraData */
   ) external override {}
 
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
@@ -1077,4 +1078,5 @@ contract FixedTermLoanHooks is MarketConstraintHooks {
   ) external virtual override {
     revert ForceBuyBacksDisabled();
   }
+  */
 }

--- a/src/access/IHooks.sol
+++ b/src/access/IHooks.sol
@@ -54,13 +54,15 @@ abstract contract IHooks {
     bytes calldata extraData
   ) external virtual;
 
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
     MarketState calldata intermediateState,
     bytes calldata extraData
   ) external virtual;
-
+  */
+ 
   function onExecuteWithdrawal(
     address lender,
     uint128 normalizedAmountWithdrawn,

--- a/src/access/MarketConstraintHooks.sol
+++ b/src/access/MarketConstraintHooks.sol
@@ -47,7 +47,7 @@ abstract contract MarketConstraintHooks is IHooks {
   uint16 internal constant MaximumDelinquencyFeeBips = 10_000;
 
   uint32 internal constant MinimumWithdrawalBatchDuration = 0;
-  uint32 internal constant MaximumWithdrawalBatchDuration = 365 days;
+  uint32 internal constant MaximumWithdrawalBatchDuration = 90 days;
 
   uint16 internal constant MinimumAnnualInterestBips = 0;
   uint16 internal constant MaximumAnnualInterestBips = 10_000;

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -200,6 +200,7 @@ contract WildcatMarket is
     _writeState(state);
   }
 
+  /*
   function forceBuyBack(address lender, uint256 normalizedAmount) external nonReentrant onlyBorrower {
     MarketState memory state = _getUpdatedState();
     if (state.isClosed) revert_BuyBackOnClosedMarket();
@@ -225,7 +226,8 @@ contract WildcatMarket is
 
     _writeState(state);
   }
-
+  */
+ 
   /**
    * @dev Sets the market APR to 0% and marks market as closed.
    *

--- a/src/providers/ERC1155RoleProvider.sol
+++ b/src/providers/ERC1155RoleProvider.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'src/access/IRoleProvider.sol';
+
+interface IERC1155 {
+  function balanceOf(address account, uint256 id) external view returns (uint256);
+}
+
+interface IERC165 {
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+contract ERC1155RoleProvider is IRoleProvider {
+  error InvalidTokenAddress();
+  error InvalidERC1155();
+
+  bytes4 private constant ERC1155_INTERFACE_ID = 0xd9b67a26;
+
+  address public immutable token;
+  uint256 public immutable tokenId;
+
+  constructor(address _token, uint256 _tokenId) {
+    if (_token.code.length == 0) revert InvalidTokenAddress();
+    if (!_supportsInterface(_token, ERC1155_INTERFACE_ID)) revert InvalidERC1155();
+    token = _token;
+    tokenId = _tokenId;
+  }
+
+  function isPullProvider() external pure override returns (bool) {
+    return true;
+  }
+
+  function getCredential(address account) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata
+  ) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function _credentialTimestamp(address account) internal view returns (uint32) {
+    if (IERC1155(token).balanceOf(account, tokenId) > 0) {
+      return uint32(block.timestamp);
+    }
+    return 0;
+  }
+
+  function _supportsInterface(
+    address target,
+    bytes4 interfaceId
+  ) internal view returns (bool) {
+    try IERC165(target).supportsInterface(interfaceId) returns (bool supported) {
+      return supported;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/providers/ERC1155RoleProvider.sol
+++ b/src/providers/ERC1155RoleProvider.sol
@@ -20,9 +20,11 @@ contract ERC1155RoleProvider is IRoleProvider {
   address public immutable token;
   uint256 public immutable tokenId;
 
-  constructor(address _token, uint256 _tokenId) {
+  constructor(address _token, uint256 _tokenId, bool skipInterfaceCheck) {
     if (_token.code.length == 0) revert InvalidTokenAddress();
-    if (!_supportsInterface(_token, ERC1155_INTERFACE_ID)) revert InvalidERC1155();
+    if (!skipInterfaceCheck && !_supportsInterface(_token, ERC1155_INTERFACE_ID)) {
+      revert InvalidERC1155();
+    }
     token = _token;
     tokenId = _tokenId;
   }

--- a/src/providers/ERC20RoleProvider.sol
+++ b/src/providers/ERC20RoleProvider.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'src/access/IRoleProvider.sol';
+import 'src/interfaces/IERC20.sol';
+
+/// @notice ERC20 role provider; gates on balance >= minBalance.
+/// @dev minBalance is in token base units.
+contract ERC20RoleProvider is IRoleProvider {
+  error InvalidTokenAddress();
+
+  address public immutable token;
+  uint256 public immutable minBalance;
+
+  constructor(address _token, uint256 _minBalance) {
+    if (_token.code.length == 0) revert InvalidTokenAddress();
+    token = _token;
+    minBalance = _minBalance;
+  }
+
+  function isPullProvider() external pure override returns (bool) {
+    return true;
+  }
+
+  function getCredential(address account) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata
+  ) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function _credentialTimestamp(address account) internal view returns (uint32) {
+    if (IERC20(token).balanceOf(account) >= minBalance) {
+      return uint32(block.timestamp);
+    }
+    return 0;
+  }
+}

--- a/src/providers/ERC4626AssetsRoleProvider.sol
+++ b/src/providers/ERC4626AssetsRoleProvider.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'src/access/IRoleProvider.sol';
+
+interface IERC4626 {
+  function balanceOf(address account) external view returns (uint256);
+  function convertToAssets(uint256 shares) external view returns (uint256);
+}
+
+/// @notice ERC4626 role provider; gates on convertToAssets(balanceOf(lender)) >= minAssets.
+/// @dev minAssets is in base units of the ERC4626 underlying asset.
+contract ERC4626AssetsRoleProvider is IRoleProvider {
+  error InvalidVaultAddress();
+
+  address public immutable vault;
+  uint256 public immutable minAssets;
+
+  constructor(address _vault, uint256 _minAssets) {
+    if (_vault.code.length == 0) revert InvalidVaultAddress();
+    vault = _vault;
+    minAssets = _minAssets;
+  }
+
+  function isPullProvider() external pure override returns (bool) {
+    return true;
+  }
+
+  function getCredential(address account) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata
+  ) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function _credentialTimestamp(address account) internal view returns (uint32) {
+    uint256 shares = IERC4626(vault).balanceOf(account);
+    if (shares == 0) return 0;
+    uint256 assets = IERC4626(vault).convertToAssets(shares);
+    if (assets >= minAssets) {
+      return uint32(block.timestamp);
+    }
+    return 0;
+  }
+}

--- a/src/providers/ERC5192RoleProvider.sol
+++ b/src/providers/ERC5192RoleProvider.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'src/access/IRoleProvider.sol';
+
+interface IERC721 {
+  function ownerOf(uint256 tokenId) external view returns (address);
+}
+
+interface IERC165 {
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+interface IERC5192 {
+  function locked(uint256 tokenId) external view returns (bool);
+}
+
+/// @notice ERC5192 role provider; validates ownership of a specific tokenId.
+/// @dev If `requireLocked` is true, `locked(tokenId)` must return true.
+///      hooksData must be `abi.encodePacked(provider, abi.encode(tokenId))`.
+///      Deploy with skipInterfaceCheck for non-ERC165 tokens.
+contract ERC5192RoleProvider is IRoleProvider {
+  error InvalidTokenAddress();
+  error InvalidERC5192();
+
+  bytes4 private constant ERC721_INTERFACE_ID = 0x80ac58cd;
+  bytes4 private constant ERC5192_INTERFACE_ID = 0xb45a3c0e;
+
+  address public immutable token;
+  bool public immutable requireLocked;
+
+  constructor(address _token, bool _requireLocked, bool skipInterfaceCheck) {
+    if (_token.code.length == 0) revert InvalidTokenAddress();
+    if (
+      !skipInterfaceCheck &&
+      (!_supportsInterface(_token, ERC721_INTERFACE_ID) ||
+        !_supportsInterface(_token, ERC5192_INTERFACE_ID))
+    ) {
+      revert InvalidERC5192();
+    }
+    token = _token;
+    requireLocked = _requireLocked;
+  }
+
+  function isPullProvider() external pure override returns (bool) {
+    return false;
+  }
+
+  function getCredential(address) external pure override returns (uint32 timestamp) {
+    return 0;
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata data
+  ) external view override returns (uint32 timestamp) {
+    if (data.length != 0x20) return 0;
+    uint256 tokenId;
+    assembly {
+      tokenId := calldataload(data.offset)
+    }
+    return _credentialTimestamp(account, tokenId);
+  }
+
+  function _credentialTimestamp(address account, uint256 tokenId) internal view returns (uint32) {
+    address owner;
+    try IERC721(token).ownerOf(tokenId) returns (address tokenOwner) {
+      owner = tokenOwner;
+    } catch {
+      return 0;
+    }
+    if (owner != account) return 0;
+    if (requireLocked) {
+      try IERC5192(token).locked(tokenId) returns (bool isLocked) {
+        if (!isLocked) return 0;
+      } catch {
+        return 0;
+      }
+    }
+    return uint32(block.timestamp);
+  }
+
+  function _supportsInterface(
+    address target,
+    bytes4 interfaceId
+  ) internal view returns (bool) {
+    try IERC165(target).supportsInterface(interfaceId) returns (bool supported) {
+      return supported;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/providers/ERC5484RoleProvider.sol
+++ b/src/providers/ERC5484RoleProvider.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'src/access/IRoleProvider.sol';
+
+interface IERC721 {
+  function ownerOf(uint256 tokenId) external view returns (address);
+}
+
+interface IERC165 {
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+interface IERC5484 {
+  function burnAuth(uint256 tokenId) external view returns (uint256);
+}
+
+/// @notice ERC5484 role provider; validates ownership of a specific tokenId.
+/// @dev `allowedBurnAuthMask` is a bitmask of allowed burnAuth values:
+///      bit 0: IssuerOnly, bit 1: OwnerOnly, bit 2: Both, bit 3: Neither.
+///      hooksData must be `abi.encodePacked(provider, abi.encode(tokenId))`.
+///      Deploy with skipInterfaceCheck for non-ERC165 tokens.
+contract ERC5484RoleProvider is IRoleProvider {
+  error InvalidTokenAddress();
+  error InvalidERC5484();
+  error InvalidBurnAuthMask();
+
+  bytes4 private constant ERC721_INTERFACE_ID = 0x80ac58cd;
+  bytes4 private constant ERC5484_INTERFACE_ID = 0x0489b56f;
+
+  address public immutable token;
+  uint8 public immutable allowedBurnAuthMask;
+
+  constructor(address _token, uint8 _allowedBurnAuthMask, bool skipInterfaceCheck) {
+    if (_token.code.length == 0) revert InvalidTokenAddress();
+    if (_allowedBurnAuthMask == 0) revert InvalidBurnAuthMask();
+    if (
+      !skipInterfaceCheck &&
+      (!_supportsInterface(_token, ERC721_INTERFACE_ID) ||
+        !_supportsInterface(_token, ERC5484_INTERFACE_ID))
+    ) {
+      revert InvalidERC5484();
+    }
+    token = _token;
+    allowedBurnAuthMask = _allowedBurnAuthMask;
+  }
+
+  function isPullProvider() external pure override returns (bool) {
+    return false;
+  }
+
+  function getCredential(address) external pure override returns (uint32 timestamp) {
+    return 0;
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata data
+  ) external view override returns (uint32 timestamp) {
+    if (data.length != 0x20) return 0;
+    uint256 tokenId;
+    assembly {
+      tokenId := calldataload(data.offset)
+    }
+    return _credentialTimestamp(account, tokenId);
+  }
+
+  function _credentialTimestamp(address account, uint256 tokenId) internal view returns (uint32) {
+    address owner;
+    try IERC721(token).ownerOf(tokenId) returns (address tokenOwner) {
+      owner = tokenOwner;
+    } catch {
+      return 0;
+    }
+    if (owner != account) return 0;
+
+    uint256 burnAuthValue;
+    try IERC5484(token).burnAuth(tokenId) returns (uint256 value) {
+      burnAuthValue = value;
+    } catch {
+      return 0;
+    }
+    if (burnAuthValue > 3) return 0;
+    if ((uint256(allowedBurnAuthMask) & (uint256(1) << burnAuthValue)) == 0) {
+      return 0;
+    }
+
+    return uint32(block.timestamp);
+  }
+
+  function _supportsInterface(
+    address target,
+    bytes4 interfaceId
+  ) internal view returns (bool) {
+    try IERC165(target).supportsInterface(interfaceId) returns (bool supported) {
+      return supported;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/providers/ERC721RoleProvider.sol
+++ b/src/providers/ERC721RoleProvider.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'src/access/IRoleProvider.sol';
+
+interface IERC721 {
+  function balanceOf(address owner) external view returns (uint256);
+}
+
+contract ERC721RoleProvider is IRoleProvider {
+  address public immutable token;
+
+  constructor(address _token) {
+    token = _token;
+  }
+
+  function isPullProvider() external pure override returns (bool) {
+    return true;
+  }
+
+  function getCredential(address account) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata
+  ) external view override returns (uint32 timestamp) {
+    return _credentialTimestamp(account);
+  }
+
+  function _credentialTimestamp(address account) internal view returns (uint32) {
+    if (IERC721(token).balanceOf(account) > 0) {
+      return uint32(block.timestamp);
+    }
+    return 0;
+  }
+}

--- a/src/providers/ERC721RoleProvider.sol
+++ b/src/providers/ERC721RoleProvider.sol
@@ -11,6 +11,8 @@ interface IERC165 {
   function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }
 
+/// @notice ERC721 role provider; compatible with ERC721A/721C implementations.
+/// @dev Deploy with skipInterfaceCheck=true for non-ERC165 collections (Punks).
 contract ERC721RoleProvider is IRoleProvider {
   error InvalidTokenAddress();
   error InvalidERC721();

--- a/src/providers/ERC721RoleProvider.sol
+++ b/src/providers/ERC721RoleProvider.sol
@@ -7,10 +7,21 @@ interface IERC721 {
   function balanceOf(address owner) external view returns (uint256);
 }
 
+interface IERC165 {
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
 contract ERC721RoleProvider is IRoleProvider {
+  error InvalidTokenAddress();
+  error InvalidERC721();
+
+  bytes4 private constant ERC721_INTERFACE_ID = 0x80ac58cd;
+
   address public immutable token;
 
   constructor(address _token) {
+    if (_token.code.length == 0) revert InvalidTokenAddress();
+    if (!_supportsInterface(_token, ERC721_INTERFACE_ID)) revert InvalidERC721();
     token = _token;
   }
 
@@ -34,5 +45,16 @@ contract ERC721RoleProvider is IRoleProvider {
       return uint32(block.timestamp);
     }
     return 0;
+  }
+
+  function _supportsInterface(
+    address target,
+    bytes4 interfaceId
+  ) internal view returns (bool) {
+    try IERC165(target).supportsInterface(interfaceId) returns (bool supported) {
+      return supported;
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/providers/ERC721RoleProvider.sol
+++ b/src/providers/ERC721RoleProvider.sol
@@ -19,9 +19,11 @@ contract ERC721RoleProvider is IRoleProvider {
 
   address public immutable token;
 
-  constructor(address _token) {
+  constructor(address _token, bool skipInterfaceCheck) {
     if (_token.code.length == 0) revert InvalidTokenAddress();
-    if (!_supportsInterface(_token, ERC721_INTERFACE_ID)) revert InvalidERC721();
+    if (!skipInterfaceCheck && !_supportsInterface(_token, ERC721_INTERFACE_ID)) {
+      revert InvalidERC721();
+    }
     token = _token;
   }
 

--- a/src/providers/MerkleRoleProvider.sol
+++ b/src/providers/MerkleRoleProvider.sol
@@ -5,6 +5,12 @@ import 'src/access/IRoleProvider.sol';
 import 'solady/utils/MerkleProofLib.sol';
 
 /// @notice Merkle allowlist provider that validates address membership proofs.
+/// @dev Proofs use sorted pairs (same as Solady/OZ). Leaf = keccak256(abi.encode(account)).
+///      hooksData must be `abi.encodePacked(provider, abi.encode(proof))` where
+///      `proof` is `bytes32[]` encoded with standard ABI (offset + length + elements).
+///      Malformed hooksData returns no credential (fail closed).
+///      SDK note: when adding a helper, return `abi.encodePacked(provider, abi.encode(proof))`
+///      to match the encoding expected by AccessControlHooks.
 contract MerkleRoleProvider is IRoleProvider {
   error CallerNotAdmin();
   error InvalidAdmin();
@@ -25,6 +31,10 @@ contract MerkleRoleProvider is IRoleProvider {
     bytes32 oldRoot = root;
     root = newRoot;
     emit RootUpdated(oldRoot, newRoot);
+  }
+
+  function isMember(address account, bytes32[] calldata proof) external view returns (bool) {
+    return MerkleProofLib.verifyCalldata(proof, root, keccak256(abi.encode(account)));
   }
 
   function isPullProvider() external pure override returns (bool) {

--- a/src/providers/MerkleRoleProvider.sol
+++ b/src/providers/MerkleRoleProvider.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import 'src/access/IRoleProvider.sol';
+import 'solady/utils/MerkleProofLib.sol';
+
+/// @notice Merkle allowlist provider that validates address membership proofs.
+contract MerkleRoleProvider is IRoleProvider {
+  error CallerNotAdmin();
+  error InvalidAdmin();
+
+  event RootUpdated(bytes32 oldRoot, bytes32 newRoot);
+
+  address public immutable admin;
+  bytes32 public root;
+
+  constructor(address _admin, bytes32 _root) {
+    if (_admin == address(0)) revert InvalidAdmin();
+    admin = _admin;
+    root = _root;
+  }
+
+  function updateRoot(bytes32 newRoot) external {
+    if (msg.sender != admin) revert CallerNotAdmin();
+    bytes32 oldRoot = root;
+    root = newRoot;
+    emit RootUpdated(oldRoot, newRoot);
+  }
+
+  function isPullProvider() external pure override returns (bool) {
+    return false;
+  }
+
+  function getCredential(address) external pure override returns (uint32 timestamp) {
+    return 0;
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata data
+  ) external view override returns (uint32 timestamp) {
+    if (data.length < 0x40) return 0;
+    uint256 offset;
+    assembly {
+      offset := calldataload(data.offset)
+    }
+    if ((offset & 0x1f) != 0 || offset + 0x20 > data.length) return 0;
+    bytes32[] calldata proof;
+    assembly {
+      let proofOffset := add(data.offset, offset)
+      proof.length := calldataload(proofOffset)
+      proof.offset := add(proofOffset, 0x20)
+    }
+    if (proof.length > (data.length - offset - 0x20) / 0x20) return 0;
+    bytes32 leaf = keccak256(abi.encode(account));
+    if (MerkleProofLib.verifyCalldata(proof, root, leaf)) {
+      return uint32(block.timestamp);
+    }
+    return 0;
+  }
+}

--- a/src/types/HooksConfig.sol
+++ b/src/types/HooksConfig.sol
@@ -878,7 +878,8 @@ library LibHooksConfig {
       }
     }
   }
-
+  
+  /* DEV: hook removed as force buyback has been disabled in initial V2 launch
   // ========================================================================== //
   //                           Hook for forced buyback                          //
   // ========================================================================== //
@@ -892,6 +893,7 @@ library LibHooksConfig {
   uint256 internal constant ForceBuyBackHook_ExtraData_Length_Offset = 0x0220;
   uint256 internal constant ForceBuyBackHook_ExtraData_TailOffset = 0x0240;
 
+  
   function onForceBuyBack(
     HooksConfig self,
     address lender,
@@ -934,4 +936,5 @@ library LibHooksConfig {
       }
     }
   }
+  */
 }

--- a/test/HooksIntegration.t.sol
+++ b/test/HooksIntegration.t.sol
@@ -554,6 +554,7 @@ contract HooksIntegrationTest is BaseMarketTest {
   //                               onForceBuyBack                               //
   // ========================================================================== //
 
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
   function test_onForceBuyBack(
     address lender,
     // uint112 scaledAmount,
@@ -584,4 +585,5 @@ contract HooksIntegrationTest is BaseMarketTest {
     emit IERC20.Transfer(lender, borrower, 1e18);
     _callMarket(_calldata, '', 'forceBuyBack');
   }
+  */
 }

--- a/test/access/AccessControlHooks.t.sol
+++ b/test/access/AccessControlHooks.t.sol
@@ -701,7 +701,7 @@ contract AccessControlHooksTest is Test, Assertions, Prankster {
     assertEq(constraints.minimumWithdrawalBatchDuration, 0, 'minimumWithdrawalBatchDuration');
     assertEq(
       constraints.maximumWithdrawalBatchDuration,
-      365 days,
+      90 days,
       'maximumWithdrawalBatchDuration'
     );
     assertEq(constraints.minimumAnnualInterestBips, 0, 'minimumAnnualInterestBips');

--- a/test/access/FixedTermLoanHooks.t.sol
+++ b/test/access/FixedTermLoanHooks.t.sol
@@ -1127,6 +1127,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
     hooks.onCloseMarket(state, '');
   }
 
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
   function test_forceBuyBack_ForceBuyBacksDisabled() external {
     
     DeployMarketInputs memory inputs;
@@ -1143,4 +1144,6 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
     MarketState memory state;
     hooks.onForceBuyBack(address(1), 0, state, '');
   }
+  */
+ 
 }

--- a/test/access/FixedTermLoanHooks.t.sol
+++ b/test/access/FixedTermLoanHooks.t.sol
@@ -887,7 +887,7 @@ contract FixedTermLoanHooksTest is Test, Assertions, Prankster {
     assertEq(constraints.minimumWithdrawalBatchDuration, 0, 'minimumWithdrawalBatchDuration');
     assertEq(
       constraints.maximumWithdrawalBatchDuration,
-      365 days,
+      90 days,
       'maximumWithdrawalBatchDuration'
     );
     assertEq(constraints.minimumAnnualInterestBips, 0, 'minimumAnnualInterestBips');

--- a/test/lens/MarketLens.t.sol
+++ b/test/lens/MarketLens.t.sol
@@ -118,7 +118,7 @@ contract MarketDataTest is BaseMarketTest {
     assertEq(constraints.minimumWithdrawalBatchDuration, 0, 'minimumWithdrawalBatchDuration');
     assertEq(
       constraints.maximumWithdrawalBatchDuration,
-      365 days,
+      90 days,
       'maximumWithdrawalBatchDuration'
     );
     assertEq(constraints.minimumAnnualInterestBips, 0, 'minimumAnnualInterestBips');

--- a/test/market/WildcatMarket.t.sol
+++ b/test/market/WildcatMarket.t.sol
@@ -731,16 +731,21 @@ contract WildcatMarketTest is BaseMarketTest {
     market.forceBuyBack(alice, 5e17);
   }
 
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
+
   function test_forceBuyBack_NullBuyBackAmount() external asAccount(borrower) {
     vm.expectRevert(IMarketEventsAndErrors.NullBuyBackAmount.selector);
     market.forceBuyBack(alice, 0);
   }
+  */
 
   function test_forceBuyBack_ForceBuyBacksDisabled() external asAccount(borrower) {
     _deposit(alice, 1e18);
     vm.expectRevert(AccessControlHooks.ForceBuyBacksDisabled.selector);
     market.forceBuyBack(alice, 1e17);
   }
+
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
 
   function test_forceBuyBack() external asAccount(borrower) {
     parameters.allowForceBuyBack = true;
@@ -757,4 +762,5 @@ contract WildcatMarketTest is BaseMarketTest {
     emit IMarketEventsAndErrors.ForceBuyBack(alice, 1e17, 1e17);
     market.forceBuyBack(alice, 1e17);
   }
+  */
 }

--- a/test/market/WildcatMarket.t.sol
+++ b/test/market/WildcatMarket.t.sol
@@ -710,10 +710,13 @@ contract WildcatMarketTest is BaseMarketTest {
     market.transfer(bob, 0.5e18);
     assertEq(market.balanceOf(bob), 1e18, 'bob.balance');
   }
+  
+  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
 
   // ========================================================================== //
   //                                Force Buyback                               //
   // ========================================================================== //
+  
   function test_forceBuyBack_NotApprovedBorrower() external {
     vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
     market.forceBuyBack(alice, 0);
@@ -731,13 +734,11 @@ contract WildcatMarketTest is BaseMarketTest {
     market.forceBuyBack(alice, 5e17);
   }
 
-  /* DEV: test disabled as force buyback has been disabled in initial V2 launch
-
+  
   function test_forceBuyBack_NullBuyBackAmount() external asAccount(borrower) {
     vm.expectRevert(IMarketEventsAndErrors.NullBuyBackAmount.selector);
     market.forceBuyBack(alice, 0);
   }
-  */
 
   function test_forceBuyBack_ForceBuyBacksDisabled() external asAccount(borrower) {
     _deposit(alice, 1e18);

--- a/test/providers/ERC1155RoleProvider.t.sol
+++ b/test/providers/ERC1155RoleProvider.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import { MockERC1155 } from 'solmate/test/utils/mocks/MockERC1155.sol';
+
+import '../BaseMarketTest.sol';
+import { fastForward } from '../helpers/VmUtils.sol';
+import 'src/providers/ERC1155RoleProvider.sol';
+
+contract NonERC1155 {}
+
+contract ERC1155RoleProviderTest is BaseMarketTest {
+  MockERC1155 internal token;
+  ERC1155RoleProvider internal provider;
+
+  address internal approvedLender;
+  address internal unapprovedLender;
+  uint256 internal constant tokenId = 1;
+
+  function setUp() public override {
+    super.setUp();
+    _deauthorizeLender(alice);
+
+    approvedLender = alice;
+    unapprovedLender = bob;
+
+    token = new MockERC1155();
+    provider = new ERC1155RoleProvider(address(token), tokenId);
+    token.mint(approvedLender, tokenId, 1, '');
+
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), type(uint32).max);
+    vm.stopPrank();
+  }
+
+  /// @dev Holders of the configured ERC1155 tokenId can deposit.
+  function test_deposit_allows_erc1155_holder() external {
+    _deposit(approvedLender, 1e18, false);
+  }
+
+  /// @dev Non-holders are rejected even if they can fund the deposit.
+  function test_deposit_reverts_erc1155_nonholder() external {
+    uint256 amount = 1e18;
+    asset.mint(unapprovedLender, amount);
+    assertEq(token.balanceOf(unapprovedLender, tokenId), 0, 'expected no ERC1155 balance');
+
+    vm.startPrank(unapprovedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
+  /// @dev Holding a different tokenId does not grant access.
+  function test_deposit_reverts_erc1155_wrong_token_id() external {
+    uint256 otherTokenId = tokenId + 1;
+    token.mint(unapprovedLender, otherTokenId, 1, '');
+
+    uint256 amount = 1e18;
+    asset.mint(unapprovedLender, amount);
+
+    assertEq(token.balanceOf(unapprovedLender, tokenId), 0, 'expected no configured balance');
+    assertEq(token.balanceOf(unapprovedLender, otherTokenId), 1, 'expected other token balance');
+
+    vm.startPrank(unapprovedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
+  /// @dev Pull-provider credentials remain valid until TTL expiry.
+  function test_deposit_erc1155_expires_after_ttl() external {
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), 1);
+    vm.stopPrank();
+
+    _deposit(approvedLender, 1e18, false);
+
+    vm.prank(approvedLender);
+    token.safeTransferFrom(approvedLender, unapprovedLender, tokenId, 1, '');
+
+    _deposit(approvedLender, 1e18, false);
+
+    fastForward(2);
+
+    uint256 amount = 1e18;
+    asset.mint(approvedLender, amount);
+
+    vm.startPrank(approvedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
+  function test_constructor_reverts_without_code() external {
+    vm.expectRevert(ERC1155RoleProvider.InvalidTokenAddress.selector);
+    new ERC1155RoleProvider(address(0), tokenId);
+  }
+
+  function test_constructor_reverts_without_erc1155_interface() external {
+    NonERC1155 nonErc1155 = new NonERC1155();
+    vm.expectRevert(ERC1155RoleProvider.InvalidERC1155.selector);
+    new ERC1155RoleProvider(address(nonErc1155), tokenId);
+  }
+}

--- a/test/providers/ERC1155RoleProvider.t.sol
+++ b/test/providers/ERC1155RoleProvider.t.sol
@@ -25,7 +25,7 @@ contract ERC1155RoleProviderTest is BaseMarketTest {
     unapprovedLender = bob;
 
     token = new MockERC1155();
-    provider = new ERC1155RoleProvider(address(token), tokenId);
+    provider = new ERC1155RoleProvider(address(token), tokenId, false);
     token.mint(approvedLender, tokenId, 1, '');
 
     vm.startPrank(parameters.borrower);
@@ -96,12 +96,17 @@ contract ERC1155RoleProviderTest is BaseMarketTest {
 
   function test_constructor_reverts_without_code() external {
     vm.expectRevert(ERC1155RoleProvider.InvalidTokenAddress.selector);
-    new ERC1155RoleProvider(address(0), tokenId);
+    new ERC1155RoleProvider(address(0), tokenId, false);
   }
 
   function test_constructor_reverts_without_erc1155_interface() external {
     NonERC1155 nonErc1155 = new NonERC1155();
     vm.expectRevert(ERC1155RoleProvider.InvalidERC1155.selector);
-    new ERC1155RoleProvider(address(nonErc1155), tokenId);
+    new ERC1155RoleProvider(address(nonErc1155), tokenId, false);
+  }
+
+  function test_constructor_allows_skip_interface_check() external {
+    NonERC1155 nonErc1155 = new NonERC1155();
+    new ERC1155RoleProvider(address(nonErc1155), tokenId, true);
   }
 }

--- a/test/providers/ERC20RoleProvider.t.sol
+++ b/test/providers/ERC20RoleProvider.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import { MockERC20 } from 'solmate/test/utils/mocks/MockERC20.sol';
+
+import '../BaseMarketTest.sol';
+import { fastForward } from '../helpers/VmUtils.sol';
+import 'src/providers/ERC20RoleProvider.sol';
+
+contract ERC20RoleProviderTest is BaseMarketTest {
+  MockERC20 internal gatingToken;
+  ERC20RoleProvider internal provider;
+
+  address internal approvedLender;
+  address internal unapprovedLender;
+
+  uint256 internal minBalance = 100e18;
+
+  function setUp() public override {
+    super.setUp();
+    _deauthorizeLender(alice);
+
+    approvedLender = alice;
+    unapprovedLender = bob;
+
+    gatingToken = new MockERC20('Gate', 'GATE', 18);
+    provider = new ERC20RoleProvider(address(gatingToken), minBalance);
+    gatingToken.mint(approvedLender, minBalance);
+
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), type(uint32).max);
+    vm.stopPrank();
+  }
+
+  /// @dev Holders of the configured ERC20 can deposit.
+  function test_deposit_allows_erc20_holder() external {
+    _deposit(approvedLender, 1e18, false);
+  }
+
+  /// @dev Non-holders are rejected even if they can fund the deposit.
+  function test_deposit_reverts_erc20_below_min_balance() external {
+    uint256 amount = 1e18;
+    asset.mint(unapprovedLender, amount);
+
+    vm.startPrank(unapprovedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
+  /// @dev Pull-provider credentials remain valid until TTL expiry.
+  function test_deposit_erc20_expires_after_ttl() external {
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), 1);
+    vm.stopPrank();
+
+    _deposit(approvedLender, 1e18, false);
+
+    vm.prank(approvedLender);
+    gatingToken.transfer(unapprovedLender, minBalance);
+
+    _deposit(approvedLender, 1e18, false);
+
+    fastForward(2);
+
+    uint256 amount = 1e18;
+    asset.mint(approvedLender, amount);
+
+    vm.startPrank(approvedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
+  function test_constructor_reverts_without_code() external {
+    vm.expectRevert(ERC20RoleProvider.InvalidTokenAddress.selector);
+    new ERC20RoleProvider(address(0), minBalance);
+  }
+}

--- a/test/providers/ERC4626AssetsRoleProvider.t.sol
+++ b/test/providers/ERC4626AssetsRoleProvider.t.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import { MockERC20 } from 'solmate/test/utils/mocks/MockERC20.sol';
+import { MockERC4626 } from 'lib/solady/test/utils/mocks/MockERC4626.sol';
+
+import '../BaseMarketTest.sol';
+import { fastForward } from '../helpers/VmUtils.sol';
+import 'src/providers/ERC4626AssetsRoleProvider.sol';
+
+contract ERC4626AssetsRoleProviderTest is BaseMarketTest {
+  MockERC20 internal underlying;
+  MockERC4626 internal vault;
+  ERC4626AssetsRoleProvider internal provider;
+
+  address internal approvedLender;
+  address internal unapprovedLender;
+
+  uint256 internal minAssets = 100e18;
+
+  function setUp() public override {
+    super.setUp();
+    _deauthorizeLender(alice);
+
+    approvedLender = alice;
+    unapprovedLender = bob;
+
+    underlying = new MockERC20('Underlying', 'UND', 18);
+    vault = new MockERC4626(address(underlying), 'Vault', 'VLT', false, 0);
+    provider = new ERC4626AssetsRoleProvider(address(vault), minAssets);
+
+    underlying.mint(approvedLender, minAssets);
+    vm.startPrank(approvedLender);
+    underlying.approve(address(vault), minAssets);
+    vault.deposit(minAssets, approvedLender);
+    vm.stopPrank();
+
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), type(uint32).max);
+    vm.stopPrank();
+  }
+
+  /// @dev Holders with enough assets in the vault can deposit.
+  function test_deposit_allows_erc4626_assets_holder() external {
+    _deposit(approvedLender, 1e18, false);
+  }
+
+  /// @dev Accounts below the asset threshold are rejected.
+  function test_deposit_reverts_erc4626_below_min_assets() external {
+    uint256 amount = 1e18;
+    asset.mint(unapprovedLender, amount);
+
+    vm.startPrank(unapprovedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
+  /// @dev Pull-provider credentials remain valid until TTL expiry.
+  function test_deposit_erc4626_expires_after_ttl() external {
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), 1);
+    vm.stopPrank();
+
+    _deposit(approvedLender, 1e18, false);
+
+    vm.startPrank(approvedLender);
+    vault.redeem(vault.balanceOf(approvedLender), approvedLender, approvedLender);
+    vm.stopPrank();
+
+    _deposit(approvedLender, 1e18, false);
+
+    fastForward(2);
+
+    uint256 amount = 1e18;
+    asset.mint(approvedLender, amount);
+
+    vm.startPrank(approvedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
+  function test_constructor_reverts_without_code() external {
+    vm.expectRevert(ERC4626AssetsRoleProvider.InvalidVaultAddress.selector);
+    new ERC4626AssetsRoleProvider(address(0), minAssets);
+  }
+}

--- a/test/providers/ERC5192RoleProvider.t.sol
+++ b/test/providers/ERC5192RoleProvider.t.sol
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import { MockERC721 } from 'solmate/test/utils/mocks/MockERC721.sol';
+
+import '../BaseMarketTest.sol';
+import 'src/providers/ERC5192RoleProvider.sol';
+
+contract MockERC5192 is MockERC721 {
+  mapping(uint256 => bool) internal lockedById;
+
+  constructor() MockERC721('Access', 'ACCESS') {}
+
+  function locked(uint256 tokenId) external view returns (bool) {
+    return lockedById[tokenId];
+  }
+
+  function setLocked(uint256 tokenId, bool isLocked) external {
+    lockedById[tokenId] = isLocked;
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+    return interfaceId == 0xb45a3c0e || super.supportsInterface(interfaceId);
+  }
+}
+
+contract ERC5192RoleProviderTest is BaseMarketTest {
+  MockERC5192 internal nft;
+  ERC5192RoleProvider internal provider;
+
+  address internal approvedLender;
+  address internal unapprovedLender;
+  uint256 internal tokenId;
+
+  function setUp() public override {
+    super.setUp();
+    _deauthorizeLender(alice);
+
+    approvedLender = alice;
+    unapprovedLender = bob;
+
+    tokenId = 1;
+    nft = new MockERC5192();
+    provider = new ERC5192RoleProvider(address(nft), true, false);
+    nft.mint(approvedLender, tokenId);
+    nft.setLocked(tokenId, true);
+
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), type(uint32).max);
+    vm.stopPrank();
+  }
+
+  /// @dev Holders of the configured ERC5192 can deposit with a locked token.
+  function test_deposit_allows_erc5192_holder_locked() external {
+    bytes memory hooksData = _hooksData(address(provider), tokenId);
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Locked enforcement blocks deposits for unlocked tokens.
+  function test_deposit_reverts_erc5192_unlocked_when_required() external {
+    nft.setLocked(tokenId, false);
+    bytes memory hooksData = _hooksData(address(provider), tokenId);
+    _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Tokens can be used without requiring locked enforcement.
+  function test_deposit_allows_erc5192_unlocked_when_not_required() external {
+    nft.setLocked(tokenId, false);
+    ERC5192RoleProvider openProvider = new ERC5192RoleProvider(address(nft), false, false);
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(openProvider), type(uint32).max);
+    vm.stopPrank();
+
+    bytes memory hooksData = _hooksData(address(openProvider), tokenId);
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Non-holders are rejected even if they can fund the deposit.
+  function test_deposit_reverts_erc5192_nonholder() external {
+    bytes memory hooksData = _hooksData(address(provider), tokenId);
+    _expectDepositRevertNotApproved(unapprovedLender, 1e18, hooksData);
+  }
+
+  function test_constructor_reverts_without_code() external {
+    vm.expectRevert(ERC5192RoleProvider.InvalidTokenAddress.selector);
+    new ERC5192RoleProvider(address(0), true, false);
+  }
+
+  function test_constructor_reverts_without_erc5192_interface() external {
+    MockERC721 nonErc5192 = new MockERC721('Plain', 'PLN');
+    vm.expectRevert(ERC5192RoleProvider.InvalidERC5192.selector);
+    new ERC5192RoleProvider(address(nonErc5192), true, false);
+  }
+
+  function test_constructor_allows_skip_interface_check() external {
+    MockERC721 nonErc5192 = new MockERC721('Plain', 'PLN');
+    new ERC5192RoleProvider(address(nonErc5192), true, true);
+  }
+
+  function _depositWithHooksData(
+    address from,
+    uint256 amount,
+    bytes memory hooksData
+  ) internal returns (uint256) {
+    MarketState memory state = pendingState();
+    (uint256 currentScaledBalance, uint256 currentBalance) = _getBalance(state, from);
+
+    asset.mint(from, amount);
+
+    vm.startPrank(from);
+    asset.approve(address(market), amount);
+
+    (uint104 scaledAmount, uint256 expectedNormalizedAmount) = _trackDeposit(state, from, amount);
+
+    bytes memory data = abi.encodePacked(
+      abi.encodeWithSelector(WildcatMarket.depositUpTo.selector, amount),
+      hooksData
+    );
+    (bool success, bytes memory returnData) = address(market).call(data);
+    vm.stopPrank();
+
+    if (!success) {
+      assembly {
+        revert(add(returnData, 0x20), mload(returnData))
+      }
+    }
+
+    uint256 actualNormalizedAmount = abi.decode(returnData, (uint256));
+    assertEq(actualNormalizedAmount, expectedNormalizedAmount, 'Actual amount deposited');
+    _checkState(state);
+    assertEq(
+      market.balanceOf(from),
+      currentBalance + state.normalizeAmount(scaledAmount),
+      'Resulting balance != old balance + normalize(scale(deposit))'
+    );
+    assertApproxEqAbs(
+      market.balanceOf(from),
+      currentBalance + amount,
+      1,
+      'Resulting balance not within 1 wei of old balance + amount deposited'
+    );
+    assertEq(
+      market.scaledBalanceOf(from),
+      currentScaledBalance + scaledAmount,
+      'Resulting scaled balance'
+    );
+    return actualNormalizedAmount;
+  }
+
+  function _expectDepositRevertNotApproved(
+    address from,
+    uint256 amount,
+    bytes memory hooksData
+  ) internal {
+    asset.mint(from, amount);
+
+    vm.startPrank(from);
+    asset.approve(address(market), amount);
+
+    bytes memory data = abi.encodePacked(
+      abi.encodeWithSelector(WildcatMarket.depositUpTo.selector, amount),
+      hooksData
+    );
+    (bool success, bytes memory returnData) = address(market).call(data);
+    vm.stopPrank();
+
+    assertFalse(success, 'expected deposit to revert');
+    bytes4 selector;
+    assembly {
+      selector := mload(add(returnData, 0x20))
+    }
+    assertEq(selector, AccessControlHooks.NotApprovedLender.selector, 'expected NotApprovedLender');
+  }
+
+  function _hooksData(address providerAddress, uint256 id) internal pure returns (bytes memory) {
+    return abi.encodePacked(providerAddress, abi.encode(id));
+  }
+}

--- a/test/providers/ERC5484RoleProvider.t.sol
+++ b/test/providers/ERC5484RoleProvider.t.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import { MockERC721 } from 'solmate/test/utils/mocks/MockERC721.sol';
+
+import '../BaseMarketTest.sol';
+import 'src/providers/ERC5484RoleProvider.sol';
+
+contract MockERC5484 is MockERC721 {
+  mapping(uint256 => uint256) internal burnAuthById;
+
+  constructor() MockERC721('Access', 'ACCESS') {}
+
+  function burnAuth(uint256 tokenId) external view returns (uint256) {
+    return burnAuthById[tokenId];
+  }
+
+  function setBurnAuth(uint256 tokenId, uint256 value) external {
+    burnAuthById[tokenId] = value;
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+    return interfaceId == 0x0489b56f || super.supportsInterface(interfaceId);
+  }
+}
+
+contract ERC5484RoleProviderTest is BaseMarketTest {
+  MockERC5484 internal nft;
+  ERC5484RoleProvider internal provider;
+
+  address internal approvedLender;
+  address internal unapprovedLender;
+  uint256 internal tokenId;
+
+  uint8 internal issuerOnlyMask = 1 << 0;
+  uint8 internal issuerOrOwnerMask = (1 << 0) | (1 << 1);
+
+  function setUp() public override {
+    super.setUp();
+    _deauthorizeLender(alice);
+
+    approvedLender = alice;
+    unapprovedLender = bob;
+
+    tokenId = 1;
+    nft = new MockERC5484();
+    provider = new ERC5484RoleProvider(address(nft), issuerOnlyMask, false);
+    nft.mint(approvedLender, tokenId);
+    nft.setBurnAuth(tokenId, 0);
+
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), type(uint32).max);
+    vm.stopPrank();
+  }
+
+  /// @dev Holders with an allowed burnAuth can deposit.
+  function test_deposit_allows_erc5484_allowed_burn_auth() external {
+    bytes memory hooksData = _hooksData(address(provider), tokenId);
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Disallowed burnAuth values are rejected.
+  function test_deposit_reverts_erc5484_disallowed_burn_auth() external {
+    nft.setBurnAuth(tokenId, 1);
+    bytes memory hooksData = _hooksData(address(provider), tokenId);
+    _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Multiple burnAuth values can be allowed via the mask.
+  function test_deposit_allows_erc5484_multiple_burn_auth() external {
+    ERC5484RoleProvider openProvider = new ERC5484RoleProvider(
+      address(nft),
+      issuerOrOwnerMask,
+      false
+    );
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(openProvider), type(uint32).max);
+    vm.stopPrank();
+
+    nft.setBurnAuth(tokenId, 1);
+    bytes memory hooksData = _hooksData(address(openProvider), tokenId);
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Non-holders are rejected even if burnAuth is allowed.
+  function test_deposit_reverts_erc5484_nonholder() external {
+    bytes memory hooksData = _hooksData(address(provider), tokenId);
+    _expectDepositRevertNotApproved(unapprovedLender, 1e18, hooksData);
+  }
+
+  function test_constructor_reverts_without_code() external {
+    vm.expectRevert(ERC5484RoleProvider.InvalidTokenAddress.selector);
+    new ERC5484RoleProvider(address(0), issuerOnlyMask, false);
+  }
+
+  function test_constructor_reverts_without_erc5484_interface() external {
+    MockERC721 nonErc5484 = new MockERC721('Plain', 'PLN');
+    vm.expectRevert(ERC5484RoleProvider.InvalidERC5484.selector);
+    new ERC5484RoleProvider(address(nonErc5484), issuerOnlyMask, false);
+  }
+
+  function test_constructor_reverts_without_burn_auth_mask() external {
+    vm.expectRevert(ERC5484RoleProvider.InvalidBurnAuthMask.selector);
+    new ERC5484RoleProvider(address(nft), 0, false);
+  }
+
+  function test_constructor_allows_skip_interface_check() external {
+    MockERC721 nonErc5484 = new MockERC721('Plain', 'PLN');
+    new ERC5484RoleProvider(address(nonErc5484), issuerOnlyMask, true);
+  }
+
+  function _depositWithHooksData(
+    address from,
+    uint256 amount,
+    bytes memory hooksData
+  ) internal returns (uint256) {
+    MarketState memory state = pendingState();
+    (uint256 currentScaledBalance, uint256 currentBalance) = _getBalance(state, from);
+
+    asset.mint(from, amount);
+
+    vm.startPrank(from);
+    asset.approve(address(market), amount);
+
+    (uint104 scaledAmount, uint256 expectedNormalizedAmount) = _trackDeposit(state, from, amount);
+
+    bytes memory data = abi.encodePacked(
+      abi.encodeWithSelector(WildcatMarket.depositUpTo.selector, amount),
+      hooksData
+    );
+    (bool success, bytes memory returnData) = address(market).call(data);
+    vm.stopPrank();
+
+    if (!success) {
+      assembly {
+        revert(add(returnData, 0x20), mload(returnData))
+      }
+    }
+
+    uint256 actualNormalizedAmount = abi.decode(returnData, (uint256));
+    assertEq(actualNormalizedAmount, expectedNormalizedAmount, 'Actual amount deposited');
+    _checkState(state);
+    assertEq(
+      market.balanceOf(from),
+      currentBalance + state.normalizeAmount(scaledAmount),
+      'Resulting balance != old balance + normalize(scale(deposit))'
+    );
+    assertApproxEqAbs(
+      market.balanceOf(from),
+      currentBalance + amount,
+      1,
+      'Resulting balance not within 1 wei of old balance + amount deposited'
+    );
+    assertEq(
+      market.scaledBalanceOf(from),
+      currentScaledBalance + scaledAmount,
+      'Resulting scaled balance'
+    );
+    return actualNormalizedAmount;
+  }
+
+  function _expectDepositRevertNotApproved(
+    address from,
+    uint256 amount,
+    bytes memory hooksData
+  ) internal {
+    asset.mint(from, amount);
+
+    vm.startPrank(from);
+    asset.approve(address(market), amount);
+
+    bytes memory data = abi.encodePacked(
+      abi.encodeWithSelector(WildcatMarket.depositUpTo.selector, amount),
+      hooksData
+    );
+    (bool success, bytes memory returnData) = address(market).call(data);
+    vm.stopPrank();
+
+    assertFalse(success, 'expected deposit to revert');
+    bytes4 selector;
+    assembly {
+      selector := mload(add(returnData, 0x20))
+    }
+    assertEq(selector, AccessControlHooks.NotApprovedLender.selector, 'expected NotApprovedLender');
+  }
+
+  function _hooksData(address providerAddress, uint256 id) internal pure returns (bytes memory) {
+    return abi.encodePacked(providerAddress, abi.encode(id));
+  }
+}

--- a/test/providers/ERC721RoleProvider.t.sol
+++ b/test/providers/ERC721RoleProvider.t.sol
@@ -7,6 +7,8 @@ import '../BaseMarketTest.sol';
 import { fastForward } from '../helpers/VmUtils.sol';
 import 'src/providers/ERC721RoleProvider.sol';
 
+contract NonERC721 {}
+
 contract ERC721RoleProviderTest is BaseMarketTest {
   MockERC721 internal nft;
   ERC721RoleProvider internal provider;
@@ -48,7 +50,7 @@ contract ERC721RoleProviderTest is BaseMarketTest {
     vm.stopPrank();
   }
 
-  /// @dev Credentials invalidate when NFT moves.
+  /// @dev Pull-provider credentials remain valid until TTL expiry.
   function test_deposit_erc721_expires_after_ttl() external {
     vm.startPrank(parameters.borrower);
     hooks.addRoleProvider(address(provider), 1);
@@ -73,4 +75,14 @@ contract ERC721RoleProviderTest is BaseMarketTest {
     vm.stopPrank();
   }
 
+  function test_constructor_reverts_without_code() external {
+    vm.expectRevert(ERC721RoleProvider.InvalidTokenAddress.selector);
+    new ERC721RoleProvider(address(0));
+  }
+
+  function test_constructor_reverts_without_erc721_interface() external {
+    NonERC721 nonErc721 = new NonERC721();
+    vm.expectRevert(ERC721RoleProvider.InvalidERC721.selector);
+    new ERC721RoleProvider(address(nonErc721));
+  }
 }

--- a/test/providers/ERC721RoleProvider.t.sol
+++ b/test/providers/ERC721RoleProvider.t.sol
@@ -24,7 +24,7 @@ contract ERC721RoleProviderTest is BaseMarketTest {
     unapprovedLender = bob;
 
     nft = new MockERC721('Access', 'ACCESS');
-    provider = new ERC721RoleProvider(address(nft));
+    provider = new ERC721RoleProvider(address(nft), false);
     nft.mint(approvedLender, 1);
 
     vm.startPrank(parameters.borrower);
@@ -77,12 +77,17 @@ contract ERC721RoleProviderTest is BaseMarketTest {
 
   function test_constructor_reverts_without_code() external {
     vm.expectRevert(ERC721RoleProvider.InvalidTokenAddress.selector);
-    new ERC721RoleProvider(address(0));
+    new ERC721RoleProvider(address(0), false);
   }
 
   function test_constructor_reverts_without_erc721_interface() external {
     NonERC721 nonErc721 = new NonERC721();
     vm.expectRevert(ERC721RoleProvider.InvalidERC721.selector);
-    new ERC721RoleProvider(address(nonErc721));
+    new ERC721RoleProvider(address(nonErc721), false);
+  }
+
+  function test_constructor_allows_skip_interface_check() external {
+    NonERC721 nonErc721 = new NonERC721();
+    new ERC721RoleProvider(address(nonErc721), true);
   }
 }

--- a/test/providers/ERC721RoleProvider.t.sol
+++ b/test/providers/ERC721RoleProvider.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.20;
 import { MockERC721 } from 'solmate/test/utils/mocks/MockERC721.sol';
 
 import '../BaseMarketTest.sol';
+import { fastForward } from '../helpers/VmUtils.sol';
 import 'src/providers/ERC721RoleProvider.sol';
 
 contract ERC721RoleProviderTest is BaseMarketTest {
@@ -46,4 +47,30 @@ contract ERC721RoleProviderTest is BaseMarketTest {
     market.depositUpTo(amount);
     vm.stopPrank();
   }
+
+  /// @dev Credentials invalidate when NFT moves.
+  function test_deposit_erc721_expires_after_ttl() external {
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), 1);
+    vm.stopPrank();
+
+    _deposit(approvedLender, 1e18, false);
+
+    vm.prank(approvedLender);
+    nft.transferFrom(approvedLender, unapprovedLender, 1);
+
+    _deposit(approvedLender, 1e18, false);
+
+    fastForward(2);
+
+    uint256 amount = 1e18;
+    asset.mint(approvedLender, amount);
+
+    vm.startPrank(approvedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+
 }

--- a/test/providers/ERC721RoleProvider.t.sol
+++ b/test/providers/ERC721RoleProvider.t.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import { MockERC721 } from 'solmate/test/utils/mocks/MockERC721.sol';
+
+import '../BaseMarketTest.sol';
+import 'src/providers/ERC721RoleProvider.sol';
+
+contract ERC721RoleProviderTest is BaseMarketTest {
+  MockERC721 internal nft;
+  ERC721RoleProvider internal provider;
+
+  address internal approvedLender;
+  address internal unapprovedLender;
+
+  function setUp() public override {
+    super.setUp();
+    _deauthorizeLender(alice);
+
+    approvedLender = alice;
+    unapprovedLender = bob;
+
+    nft = new MockERC721('Access', 'ACCESS');
+    provider = new ERC721RoleProvider(address(nft));
+    nft.mint(approvedLender, 1);
+
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), type(uint32).max);
+    vm.stopPrank();
+  }
+
+  /// @dev Holders of the configured ERC721 can deposit.
+  function test_deposit_allows_erc721_holder() external {
+    _deposit(approvedLender, 1e18, false);
+  }
+
+  /// @dev Non-holders are rejected even if they can fund the deposit.
+  function test_deposit_reverts_erc721_nonholder() external {
+    uint256 amount = 1e18;
+    asset.mint(unapprovedLender, amount);
+    assertEq(nft.balanceOf(unapprovedLender), 0, 'expected no ERC721 balance');
+
+    vm.startPrank(unapprovedLender);
+    asset.approve(address(market), amount);
+    vm.expectRevert(AccessControlHooks.NotApprovedLender.selector);
+    market.depositUpTo(amount);
+    vm.stopPrank();
+  }
+}

--- a/test/providers/MerkleRoleProvider.t.sol
+++ b/test/providers/MerkleRoleProvider.t.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import '../BaseMarketTest.sol';
+import { fastForward } from '../helpers/VmUtils.sol';
+import 'src/providers/MerkleRoleProvider.sol';
+
+contract MerkleRoleProviderTest is BaseMarketTest {
+  MerkleRoleProvider internal provider;
+
+  address internal approvedLender;
+  address internal unapprovedLender;
+  address internal otherLender;
+
+  bytes32 internal approvedLeaf;
+  bytes32 internal otherLeaf;
+  bytes32 internal merkleRoot;
+
+  function setUp() public override {
+    super.setUp();
+    _deauthorizeLender(alice);
+
+    approvedLender = alice;
+    unapprovedLender = bob;
+    otherLender = address(0xbeef);
+
+    approvedLeaf = _leaf(approvedLender);
+    otherLeaf = _leaf(otherLender);
+    merkleRoot = _hashPair(approvedLeaf, otherLeaf);
+
+    provider = new MerkleRoleProvider(parameters.borrower, merkleRoot);
+
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), type(uint32).max);
+    vm.stopPrank();
+  }
+
+  /// @dev Merkle members can deposit using a valid proof.
+  function test_deposit_allows_merkle_member() external {
+    bytes32[] memory proof = _proofForApproved();
+    bytes memory hooksData = _hooksData(proof);
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Non-members are rejected even with an unrelated proof.
+  function test_deposit_reverts_merkle_nonmember() external {
+    bytes32[] memory proof = _proofForApproved();
+    bytes memory hooksData = _hooksData(proof);
+    _expectDepositRevertNotApproved(unapprovedLender, 1e18, hooksData);
+  }
+
+  /// @dev Cached credentials persist until TTL expiry after root updates.
+  function test_deposit_merkle_expires_after_ttl() external {
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(provider), 1);
+    vm.stopPrank();
+
+    bytes32[] memory proof = _proofForApproved();
+    bytes memory hooksData = _hooksData(proof);
+
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+
+    bytes32 newRoot = _hashPair(otherLeaf, _leaf(address(0xdead)));
+    vm.prank(parameters.borrower);
+    provider.updateRoot(newRoot);
+
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+
+    fastForward(2);
+
+    _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
+  }
+
+  function _depositWithHooksData(
+    address from,
+    uint256 amount,
+    bytes memory hooksData
+  ) internal returns (uint256) {
+    MarketState memory state = pendingState();
+    (uint256 currentScaledBalance, uint256 currentBalance) = _getBalance(state, from);
+
+    asset.mint(from, amount);
+
+    vm.startPrank(from);
+    asset.approve(address(market), amount);
+
+    (uint104 scaledAmount, uint256 expectedNormalizedAmount) = _trackDeposit(state, from, amount);
+
+    bytes memory data = abi.encodePacked(
+      abi.encodeWithSelector(WildcatMarket.depositUpTo.selector, amount),
+      hooksData
+    );
+    (bool success, bytes memory returnData) = address(market).call(data);
+    vm.stopPrank();
+
+    if (!success) {
+      assembly {
+        revert(add(returnData, 0x20), mload(returnData))
+      }
+    }
+
+    uint256 actualNormalizedAmount = abi.decode(returnData, (uint256));
+    assertEq(actualNormalizedAmount, expectedNormalizedAmount, 'Actual amount deposited');
+    _checkState(state);
+    assertEq(
+      market.balanceOf(from),
+      currentBalance + state.normalizeAmount(scaledAmount),
+      'Resulting balance != old balance + normalize(scale(deposit))'
+    );
+    assertApproxEqAbs(
+      market.balanceOf(from),
+      currentBalance + amount,
+      1,
+      'Resulting balance not within 1 wei of old balance + amount deposited'
+    );
+    assertEq(
+      market.scaledBalanceOf(from),
+      currentScaledBalance + scaledAmount,
+      'Resulting scaled balance'
+    );
+    return actualNormalizedAmount;
+  }
+
+  function _expectDepositRevertNotApproved(
+    address from,
+    uint256 amount,
+    bytes memory hooksData
+  ) internal {
+    asset.mint(from, amount);
+
+    vm.startPrank(from);
+    asset.approve(address(market), amount);
+
+    bytes memory data = abi.encodePacked(
+      abi.encodeWithSelector(WildcatMarket.depositUpTo.selector, amount),
+      hooksData
+    );
+    (bool success, bytes memory returnData) = address(market).call(data);
+    vm.stopPrank();
+
+    assertFalse(success, 'expected deposit to revert');
+    bytes4 selector;
+    assembly {
+      selector := mload(add(returnData, 0x20))
+    }
+    assertEq(selector, AccessControlHooks.NotApprovedLender.selector, 'expected NotApprovedLender');
+  }
+
+  function _hooksData(bytes32[] memory proof) internal view returns (bytes memory) {
+    return abi.encodePacked(address(provider), abi.encode(proof));
+  }
+
+  function _proofForApproved() internal view returns (bytes32[] memory proof) {
+    proof = new bytes32[](1);
+    proof[0] = otherLeaf;
+  }
+
+  function _leaf(address account) internal pure returns (bytes32) {
+    return keccak256(abi.encode(account));
+  }
+
+  function _hashPair(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+    return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+  }
+}

--- a/test/providers/MerkleRoleProvider.t.sol
+++ b/test/providers/MerkleRoleProvider.t.sol
@@ -140,6 +140,13 @@ contract MerkleRoleProviderTest is BaseMarketTest {
     _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
   }
 
+  /// @dev isMember mirrors proof verification against the current root.
+  function test_isMember_checks_proof() external {
+    bytes32[] memory proof = _proofForApproved();
+    assertTrue(provider.isMember(approvedLender, proof), 'expected member with proof');
+    assertFalse(provider.isMember(unapprovedLender, proof), 'expected non-member with proof');
+  }
+
   function _depositWithHooksData(
     address from,
     uint256 amount,

--- a/test/providers/MerkleRoleProvider.t.sol
+++ b/test/providers/MerkleRoleProvider.t.sol
@@ -71,6 +71,75 @@ contract MerkleRoleProviderTest is BaseMarketTest {
     _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
   }
 
+  /// @dev Only the admin can update the merkle root.
+  function test_updateRoot_reverts_non_admin() external {
+    vm.expectRevert(MerkleRoleProvider.CallerNotAdmin.selector);
+    vm.prank(unapprovedLender);
+    provider.updateRoot(bytes32(uint256(123)));
+  }
+
+  /// @dev Malformed hooks data is treated as invalid credentials.
+  function test_deposit_reverts_invalid_hooks_data_short() external {
+    bytes memory hooksData = abi.encodePacked(address(provider), bytes1(0x01));
+    _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Malformed hooks data with an invalid offset fails closed.
+  function test_deposit_reverts_invalid_hooks_data_offset() external {
+    bytes memory invalidData = abi.encodePacked(uint256(1), uint256(0));
+    bytes memory hooksData = abi.encodePacked(address(provider), invalidData);
+    _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Admin must be a non-zero address.
+  function test_constructor_reverts_invalid_admin() external {
+    vm.expectRevert(MerkleRoleProvider.InvalidAdmin.selector);
+    new MerkleRoleProvider(address(0), bytes32(0));
+  }
+
+  /// @dev Empty proofs are valid for a single-leaf tree.
+  function test_deposit_allows_single_leaf_root() external {
+    bytes32 singleRoot = _leaf(approvedLender);
+    MerkleRoleProvider singleProvider = new MerkleRoleProvider(
+      parameters.borrower,
+      singleRoot
+    );
+    vm.startPrank(parameters.borrower);
+    hooks.addRoleProvider(address(singleProvider), type(uint32).max);
+    vm.stopPrank();
+
+    bytes32[] memory proof = new bytes32[](0);
+    bytes memory hooksData = abi.encodePacked(address(singleProvider), abi.encode(proof));
+    _depositWithHooksData(approvedLender, 1e18, hooksData);
+  }
+
+  /// @dev Root updates can enable new members with a valid proof.
+  function test_updateRoot_allows_new_member() external {
+    bytes32 newLeaf = _leaf(unapprovedLender);
+    bytes32 siblingLeaf = _leaf(otherLender);
+    bytes32 newRoot = _hashPair(newLeaf, siblingLeaf);
+
+    vm.prank(parameters.borrower);
+    provider.updateRoot(newRoot);
+
+    bytes32[] memory proof = new bytes32[](1);
+    proof[0] = siblingLeaf;
+    bytes memory hooksData = _hooksData(proof);
+
+    _depositWithHooksData(unapprovedLender, 1e18, hooksData);
+  }
+
+  /// @dev Malformed hooks data with an oversized proof length fails closed.
+  function test_deposit_reverts_invalid_hooks_data_length() external {
+    bytes memory invalidData = abi.encodePacked(
+      uint256(0x20),
+      uint256(2),
+      bytes32(uint256(1))
+    );
+    bytes memory hooksData = abi.encodePacked(address(provider), invalidData);
+    _expectDepositRevertNotApproved(approvedLender, 1e18, hooksData);
+  }
+
   function _depositWithHooksData(
     address from,
     uint256 amount,

--- a/test/shared/TestConstants.sol
+++ b/test/shared/TestConstants.sol
@@ -26,7 +26,7 @@ uint16 constant MinimumDelinquencyFeeBips = 1_000;
 uint16 constant MaximumDelinquencyFeeBips = 10_000;
 
 uint32 constant MinimumWithdrawalBatchDuration = 0;
-uint32 constant MaximumWithdrawalBatchDuration = 365 days;
+uint32 constant MaximumWithdrawalBatchDuration = 90 days;
 
 uint16 constant MinimumAnnualInterestBips = 0;
 uint16 constant MaximumAnnualInterestBips = 10_000;

--- a/test/shared/mocks/MockHooks.sol
+++ b/test/shared/mocks/MockHooks.sol
@@ -50,12 +50,14 @@ event OnSetProtocolFeeBipsCalled(
   MarketState intermediateState,
   bytes extraData
 );
+/* DEV: event removed as force buyback has been disabled in initial V2 launch
 event OnForceBuyBackCalled(
   address lender,
   uint scaledAmount,
   MarketState intermediateState,
   bytes extraData
 );
+*/
 contract MockHooks is IHooks {
   bytes32 public lastCalldataHash;
   address public deployer;
@@ -275,6 +277,7 @@ contract MockHooks is IHooks {
     emit OnSetProtocolFeeBipsCalled(protocolFeeBips, intermediateState, extraData);
   }
 
+  /* DEV: hook disabled as force buyback has been disabled in initial V2 launch
   function onForceBuyBack(
     address lender,
     uint scaledAmount,
@@ -284,6 +287,7 @@ contract MockHooks is IHooks {
     lastCalldataHash = keccak256(msg.data);
     emit OnForceBuyBackCalled(lender, scaledAmount, intermediateState, extraData);
   }
+  */
 }
 
 contract MockHooksWithConfig is MockHooks {


### PR DESCRIPTION
issue [676](https://github.com/wildcat-finance/product/issues/676)

- a hook to gate market deposit
- borrower managed
- extensible for onchain and KYC

AccessControl hooks already has useOnDeposit functionality.  This feature is a set of hooks for credentialiing against onchain data such as ERC721, ERC1155, an attestation service such as EAS, or other KYC interfaces.

Initial focus is on onchain data. 


### Implemented Providers
- ERC721RoleProvider: gates on `balanceOf(lender) > 0` for a configured ERC721.
- ERC20RoleProvider: gates on `balanceOf(lender) >= minBalance` for a configured ERC20.
- ERC4626AssetsRoleProvider: gates on `convertToAssets(balanceOf(lender)) >= minAssets`.
  - For share-based gating, use `ERC20RoleProvider` against the vault share token instead.
- ERC5192RoleProvider: validates ownership of a specific tokenId via hooksData.
  - `requireLocked` enforces `locked(tokenId)` when true.
- ERC5484RoleProvider: validates ownership of a specific tokenId via hooksData.
  - `allowedBurnAuthMask` selects permitted burnAuth values (bit 0: IssuerOnly, 1: OwnerOnly, 2: Both, 3: Neither).
- ERC1155RoleProvider: gates on `balanceOf(lender, tokenId) > 0` for a configured ERC1155.
- MerkleRoleProvider: validates `keccak256(abi.encode(lender))` using a sorted-pair proof from `hooksData`.
  - Root is mutable via `updateRoot` for the configured admin.
  - `isMember(account, proof)` mirrors on-chain verification against the current root.

### Notes
- ERC721A/721C are implementation variants; ERC721RoleProvider already works.
- Some tokens may not implement ERC165; use `skipInterfaceCheck` during construction.