### PR TITLE
V25-ORG-01: Make Markets Transferable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ deployments/*/HooksFactoryRevolving-0x*/
 deployments/*/pending-admin-actions/
 deployments/*/rcf-template-sync-*.json
 deployments/*/rcf-v2-handoff*.json
+deployments/*/ceremony-evidence/
+deployments/*/ceremony-v2-5-*.json
+deployments/*/inventory-pending/
+deployments/*/plan-entries/
+deployments/*/plan-v2-5.json
+deployments/*/run-state-checkpoints/
 deployments/anvil/
 deployments/*/reconcile-report.json
 audits/

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -3,20 +3,16 @@
 Deferred tasks noted during the v2.5 pre-release cleanup pass (July 2026).
 These are not release blockers; they are queued for after the doc pass.
 
-## Deployment scripts for the v2.5 release
+## Deployment scripts for the v2.5 release — PARTIALLY DONE
 
-`script/DeployPeriodicTermHooksV21.sol` is deprecated: it targets the v2.1
-rollout and predates the five-argument `MarketLens` constructor, so it fails
-if run. The v2.5 release (RCF + PTH + lens set) needs updated deployment
-scripts.
+The ordered `script/deploy/v2-5/01` through `09` flow now covers the wrapper factory, standard and revolving factories, borrower identity registry, lens, owner actions, registration, plan generation, inventory finalization, and canary market. The market-transfer checkpoint updated factory and lens deployment inputs for the identity registry.
 
-- Reuse the inventory-management pattern from `script/deploy/DeployMarketLens.sol`
-  (labeled artifacts, canonical aliases, post-deploy wiring validation) — this
-  direction is confirmed as correct.
-- Evaluate whether the monolithic rollout-script model is right, or whether
-  per-component scripts composed by a thin orchestrator would be easier to
-  operate and audit.
-- Delete `DeployPeriodicTermHooksV21.sol` once the replacement exists.
+This is still not the final ceremony package. It must be regenerated and independently rehearsed after hooks/providers, RCF draw fees, and the event/lens hard cut are complete.
+
+`script/DeployPeriodicTermHooksV21.sol` remains deprecated: it targets the v2.1 rollout and predates the current `MarketLens` constructor.
+
+- Delete `DeployPeriodicTermHooksV21.sol` after confirming no remaining operator documentation or automation references it.
+- Regenerate the v2.5 ceremony package only after the remaining release-blocking contracts and ABIs are frozen.
 
 ## prettier-plugin-solidity upgrade
 

--- a/docs/Borrower Identity and Transfers.md
+++ b/docs/Borrower Identity and Transfers.md
@@ -1,0 +1,127 @@
+# Borrower Identity and Transfers
+
+v2.5 separates the address that operates a market from the legal borrower identity registered through the ArchController. This lets a market move from an EOA to a Safe, from one Safe to another, or to a future Borrower Account without replacing the market or resetting its state.
+
+## Identity model
+
+Each market exposes two identities:
+
+- `borrower()` is the current operational borrower. It is the exact address authorized for borrower-only market calls.
+- `borrowerPrincipal()` is the registered legal principal associated with the market. It is also the borrower namespace used for lender-facing sanctions checks and new sanctions escrows.
+
+For a market operated directly by its principal, both addresses are the same. A market operated by a recognized contract account may instead have:
+
+```text
+borrower()          = account A
+borrowerPrincipal() = principal P
+```
+
+The market stores both accepted addresses. Ordinary borrower actions do not depend on a live identity-registry lookup.
+
+## Borrower identity registry
+
+`WildcatBorrowerIdentityRegistry` recognizes contract accounts belonging to registered principals.
+
+- The current ArchController owner may approve or remove account factories.
+- An approved factory may permanently associate a deployed contract account with a currently registered principal.
+- An account cannot be zero, the principal itself, a directly registered borrower, or an account that was already registered.
+- One principal may have several registered accounts.
+- An account-to-principal association cannot be changed or removed.
+- Removing a factory prevents new registrations from that factory. It does not invalidate associations the factory already registered.
+- The registry can classify identities, but it cannot call markets, move assets, or execute a borrower transfer.
+
+`resolveBorrower(address)` accepts either a currently registered direct principal or a registered account whose principal is currently registered. Unknown, unregistered, or ambiguous identities fail closed.
+
+The Foundation remains responsible for registering legal principals in the ArchController. It does not register each borrower account or execute transfers. Approved account factories register the accounts they deploy or otherwise authenticate.
+
+## Market construction
+
+The ordinary v2.5 standard and revolving factories initialize direct markets with `borrower == borrowerPrincipal`.
+
+The shared market constructor can also represent a different initial operational borrower and principal. This is the compatibility seam for future factories that may initialize a market under a temporary construction contract while retaining the requesting principal as its legal identity. The ordinary v2.5 factories do not implement deferred origination or Borrower Account policy.
+
+## Two-step transfer
+
+Every v2.5 market exposes:
+
+```solidity
+function requestBorrowerTransfer(address newBorrower) external;
+function cancelBorrowerTransfer() external;
+function acceptBorrowerTransfer() external;
+
+function borrower() external view returns (address);
+function borrowerPrincipal() external view returns (address);
+function pendingBorrower() external view returns (address);
+```
+
+### Request
+
+Only the current borrower may request a transfer. A new request replaces any existing pending target and emits both the displaced target and the new target.
+
+The market resolves the proposed borrower through the identity registry and checks current ArchController registration. It also checks the raw sanctions status of the current borrower, current principal, proposed borrower, and proposed principal. Borrower sanctions overrides do not bypass these transfer checks.
+
+The pending borrower has no market authority before acceptance.
+
+### Cancellation
+
+Only the current borrower may cancel a pending request. Cancellation remains available without transferring authority.
+
+### Acceptance
+
+Only the pending borrower may accept. Acceptance repeats identity, registration, and raw sanctions checks against current state, then clears the pending borrower and writes the new operational borrower and resolved principal.
+
+The same path supports:
+
+- direct principal migration, `P -> Q`;
+- direct principal to account, `P -> A(P)`;
+- same-principal account rotation, `A1(P) -> A2(P)`;
+- account to direct principal, `A(P) -> Q`; and
+- account-to-account principal migration, `A(P) -> A(Q)`.
+
+The protocol does not prove that two principals represent the same legal entity. Registration remains the Foundation's onchain representation of its offchain KYB process.
+
+## What transfer changes
+
+Acceptance changes only borrower identity and pending-transfer state. It does not move or reset lender balances, withdrawal claims or batches, accrued fees, market terms, drawn amount, delinquency state, or closure state. Active, delinquent, and closed markets can all transfer.
+
+After acceptance:
+
+- the old borrower fails every borrower-only market check;
+- the new borrower controls borrower-only market actions; and
+- the market uses the new principal for new lender-facing sanctions checks and escrow derivation.
+
+Existing sanctions escrows remain under the principal namespace used when they were created.
+
+## Wrapper authority
+
+The canonical ERC-4626 wrapper follows its market directly:
+
+- `marketOwner()` resolves the live `market.borrower()`;
+- `sweep()` authorizes the live market borrower; and
+- sanctions checks and new escrow derivation resolve the live `market.borrowerPrincipal()`.
+
+The wrapper has no separate transfer step. The old borrower loses wrapper sweep authority as soon as the market transfer is accepted.
+
+## Hooks and role providers
+
+A market transfer does not transfer its hooks or role providers. Hooks may be shared by several markets, and reusable credentials belong to role providers rather than to one market. Hook administration and managed-provider administration therefore need their own explicit transfer paths.
+
+This separation is intentional. A market must not seize a shared hook or credential list merely because its borrower changed.
+
+## Batching and atomicity
+
+Each market acceptance is atomic for that market. There is no protocol transfer manager and no Wildcat-controlled coordinator.
+
+A Safe or future Borrower Account may batch several independent acceptance calls in one transaction. An EOA may need to accept them sequentially. Integrators must expose partial progress when a migration cannot fit in one borrower-controlled batch; they must not describe several unrelated transactions as atomic.
+
+## Events and lens reads
+
+Markets emit:
+
+- `BorrowerTransferRequested`, including the current borrower and principal plus the previous and new pending targets;
+- `BorrowerTransferCancelled`, including the cancelled target; and
+- `BorrowerTransferred`, including previous and new borrowers and principals.
+
+`MarketDataV2_5` exposes the current borrower through its nested market data and adds `borrowerPrincipal`, `pendingBorrower`, and `borrowerIdentityRegistry` for v2.5 consumers.
+
+Downstream systems must not assume that `market.borrower()` is itself registered in the ArchController. They should display and index the operational borrower and legal principal separately.

--- a/docs/Borrower Identity and Transfers.md
+++ b/docs/Borrower Identity and Transfers.md
@@ -23,16 +23,43 @@ The market stores both accepted addresses. Ordinary borrower actions do not depe
 `WildcatBorrowerIdentityRegistry` recognizes contract accounts belonging to registered principals.
 
 - The current ArchController owner may approve or remove account factories.
-- An approved factory may permanently associate a deployed contract account with a currently registered principal.
-- An account cannot be zero, the principal itself, a directly registered borrower, or an account that was already registered.
+- An approved factory may associate a deployed contract account with an initial registered principal.
+- An account must be a deployed contract, must differ from its principal, and must not be registered directly as a borrower in the ArchController.
+- A factory may register an account address only once. The factory that registered it remains recorded.
 - One principal may have several registered accounts.
-- An account-to-principal association cannot be changed or removed.
+- An account has one current principal at a time. Its current principal may request a two-step transfer to another registered principal.
 - Removing a factory prevents new registrations from that factory. It does not invalidate associations the factory already registered.
 - The registry can classify identities, but it cannot call markets, move assets, or execute a borrower transfer.
 
 `resolveBorrower(address)` accepts either a currently registered direct principal or a registered account whose principal is currently registered. Unknown, unregistered, or ambiguous identities fail closed.
 
 The Foundation remains responsible for registering legal principals in the ArchController. It does not register each borrower account or execute transfers. Approved account factories register the accounts they deploy or otherwise authenticate.
+
+### Account principal transfer
+
+An account principal transfer changes which registered principal the registry associates with an existing account. It does not change the account address or automatically update any market.
+
+```solidity
+function requestBorrowerAccountPrincipalTransfer(address account, address newPrincipal) external;
+function cancelBorrowerAccountPrincipalTransfer(address account) external;
+function acceptBorrowerAccountPrincipalTransfer(address account) external;
+
+function principalOf(address account) external view returns (address);
+function pendingPrincipalOf(address account) external view returns (address);
+```
+
+The current principal requests the transfer, may replace the pending principal, and may cancel it. The pending principal must accept. The registry checks the proposed principal's current ArchController registration on both request and acceptance. The account factory cannot initiate, approve, or accept the transfer.
+
+After acceptance:
+
+- `principalOf(account)` returns the new principal;
+- current-principal enumeration moves the account from the old principal to the new one;
+- factory provenance remains unchanged; and
+- existing markets keep the borrower and principal they previously accepted.
+
+A registry transfer cannot silently change a market's sanctions namespace or lender-facing identity.
+
+The registry does not rewrite an account's internal permissions. A future Borrower Account that expects its administrative authority to follow `principalOf(account)` must use the registry as its source of truth, or update its own authority as part of the same borrower-controlled operation. That requirement belongs to the account implementation and its approved factory, not to a protocol administrator.
 
 ## Market construction
 
@@ -52,6 +79,7 @@ function acceptBorrowerTransfer() external;
 function borrower() external view returns (address);
 function borrowerPrincipal() external view returns (address);
 function pendingBorrower() external view returns (address);
+function pendingBorrowerPrincipal() external view returns (address);
 ```
 
 ### Request
@@ -60,7 +88,7 @@ Only the current borrower may request a transfer. A new request replaces any exi
 
 The market resolves the proposed borrower through the identity registry and checks current ArchController registration. It also checks the raw sanctions status of the current borrower, current principal, proposed borrower, and proposed principal. Borrower sanctions overrides do not bypass these transfer checks.
 
-The pending borrower has no market authority before acceptance.
+Pending status grants no market authority before acceptance. In a same-account principal update, the address remains the current borrower and keeps only the authority it already had.
 
 ### Cancellation
 
@@ -68,7 +96,9 @@ Only the current borrower may cancel a pending request. Cancellation remains ava
 
 ### Acceptance
 
-Only the pending borrower may accept. Acceptance repeats identity, registration, and raw sanctions checks against current state, then clears the pending borrower and writes the new operational borrower and resolved principal.
+Only the pending borrower may accept. Acceptance repeats identity, registration, and raw sanctions checks against current state, then clears the pending identity and writes the new operational borrower and resolved principal.
+
+The market records the proposed principal when the transfer is requested. If the target account changes principals before acceptance, acceptance reverts. The current borrower may cancel and request the transfer again with the account's new principal.
 
 The same path supports:
 
@@ -78,6 +108,8 @@ The same path supports:
 - account to direct principal, `A(P) -> Q`; and
 - account-to-account principal migration, `A(P) -> A(Q)`.
 
+The last case may represent either a different account under `Q` or the same account after its registry principal transfer. When the address is unchanged, the account requests and accepts a market transfer to itself. The market updates only `borrowerPrincipal()` from `P` to `Q`.
+
 The protocol does not prove that two principals represent the same legal entity. Registration remains the Foundation's onchain representation of its offchain KYB process.
 
 ## What transfer changes
@@ -86,8 +118,8 @@ Acceptance changes only borrower identity and pending-transfer state. It does no
 
 After acceptance:
 
-- the old borrower fails every borrower-only market check;
-- the new borrower controls borrower-only market actions; and
+- if the borrower address changed, the previous borrower fails every borrower-only market check;
+- the accepted borrower controls borrower-only market actions; and
 - the market uses the new principal for new lender-facing sanctions checks and escrow derivation.
 
 Existing sanctions escrows remain under the principal namespace used when they were created.
@@ -100,7 +132,7 @@ The canonical ERC-4626 wrapper follows its market directly:
 - `sweep()` authorizes the live market borrower; and
 - sanctions checks and new escrow derivation resolve the live `market.borrowerPrincipal()`.
 
-The wrapper has no separate transfer step. The old borrower loses wrapper sweep authority as soon as the market transfer is accepted.
+The wrapper has no separate transfer step. If the borrower address changes, the previous borrower loses wrapper sweep authority as soon as the market transfer is accepted.
 
 ## Hooks and role providers
 
@@ -118,10 +150,25 @@ A Safe or future Borrower Account may batch several independent acceptance calls
 
 Markets emit:
 
-- `BorrowerTransferRequested`, including the current borrower and principal plus the previous and new pending targets;
-- `BorrowerTransferCancelled`, including the cancelled target; and
+- `BorrowerTransferRequested`, including the current borrower and principal plus the previous and new pending borrowers and principals;
+- `BorrowerTransferCancelled`, including the cancelled borrower and principal; and
 - `BorrowerTransferred`, including previous and new borrowers and principals.
 
-`MarketDataV2_5` exposes the current borrower through its nested market data and adds `borrowerPrincipal`, `pendingBorrower`, and `borrowerIdentityRegistry` for v2.5 consumers.
+`MarketDataV2_5` exposes the current borrower through its nested market data and adds `borrowerPrincipal`, `pendingBorrower`, `pendingBorrowerPrincipal`, and `borrowerIdentityRegistry` for v2.5 consumers.
 
 Downstream systems must not assume that `market.borrower()` is itself registered in the ArchController. They should display and index the operational borrower and legal principal separately.
+
+## Principal rotation across accounts and markets
+
+A borrower rotating from principal `P` to principal `Q` may keep its existing accounts and their internal configuration. The expected sequence is:
+
+1. The Foundation registers `Q` in the ArchController.
+2. `P` requests `A: P -> Q` for each account that should follow the borrower.
+3. `Q` accepts each account principal transfer.
+4. Each account requests and accepts a same-account transfer on every market it operates.
+5. Hook and managed-role-provider administration move through their own transfer paths where needed.
+6. The borrower confirms that the migration is complete before the Foundation removes `P`.
+
+Each acceptance is atomic for one account or market. The registry does not coordinate a global migration. A borrower-controlled Safe or Borrower Account may batch several calls, but integrations must expose partial progress when the migration spans several transactions.
+
+During partial migration, the registry may associate an account with `Q` while one of its markets still stores `P`. Ordinary borrower-only calls continue to recognize the account, but lender-facing sanctions checks continue to use the principal stored by that market until its explicit transfer is accepted.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,16 @@ inventory with per-file provenance is in [v2.5-audit-delta.md](./v2.5-audit-delt
 - Hook minimum-deposit checks compare in scaled units, so depositing exactly the advertised minimum succeeds at any scale factor.
 - The half-up `MarketState.scaleAmount` was removed; rounding directions are documented in [Scale Factor](./Scale%20Factor.md#rounding).
 
+### Borrower identity and market transfers
+
+- Split market identity into a stored operational `borrower` and registered `borrowerPrincipal`. Ordinary borrower calls still require the exact operational borrower, while lender-facing sanctions checks use the principal namespace.
+- Added `WildcatBorrowerIdentityRegistry`. The ArchController owner approves account factories, approved factories register immutable account-to-principal associations, and one principal may have several accounts. Removing a factory blocks only future registrations.
+- Added borrower-requested, target-accepted market transfers with replacement, cancellation, acceptance-time identity and registration checks, and raw sanctions checks for the current and proposed borrower/principal identities.
+- Transfers support direct principals, same-principal account rotation, and principal migration. They preserve balances, lender claims, accrued fees, market terms, revolving drawn amount, delinquency, and lifecycle state.
+- Market construction now supports different initial borrower and principal addresses so future account-aware or deferred-origination factories can use the same identity seam without changing ordinary v2.5 factories.
+- Wrapper sweep authority now resolves the live market borrower, and wrapper sanctions checks resolve the live market principal. Hooks and role providers do not move implicitly with a market transfer.
+- Added borrower transfer events and v2.5 lens fields for principal, pending borrower, and identity-registry discovery. See [Borrower Identity and Transfers](./Borrower%20Identity%20and%20Transfers.md).
+
 ### ERC-4626 wrapper
 
 - Wrapper execution paths converted to floor-consistent arithmetic matching v2.5 market transfers (previews keep their spec rounding); `maxDeposit`/`maxMint`/`maxWithdraw` are exact and executable whenever nonzero.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,12 +26,12 @@ inventory with per-file provenance is in [v2.5-audit-delta.md](./v2.5-audit-delt
 ### Borrower identity and market transfers
 
 - Split market identity into a stored operational `borrower` and registered `borrowerPrincipal`. Ordinary borrower calls still require the exact operational borrower, while lender-facing sanctions checks use the principal namespace.
-- Added `WildcatBorrowerIdentityRegistry`. The ArchController owner approves account factories, approved factories register immutable account-to-principal associations, and one principal may have several accounts. Removing a factory blocks only future registrations.
-- Added borrower-requested, target-accepted market transfers with replacement, cancellation, acceptance-time identity and registration checks, and raw sanctions checks for the current and proposed borrower/principal identities.
+- Added `WildcatBorrowerIdentityRegistry`. The ArchController owner approves account factories, approved factories register each account once, and one principal may have several accounts. Account principals may transfer an account to another registered principal through a two-step path. Removing a factory blocks only future registrations.
+- Added borrower-requested, target-accepted market transfers with replacement, cancellation, acceptance-time identity and registration checks, and raw sanctions checks for the current and proposed borrower/principal identities. An account may use the same path to keep its market ownership while updating the market's stored principal.
 - Transfers support direct principals, same-principal account rotation, and principal migration. They preserve balances, lender claims, accrued fees, market terms, revolving drawn amount, delinquency, and lifecycle state.
 - Market construction now supports different initial borrower and principal addresses so future account-aware or deferred-origination factories can use the same identity seam without changing ordinary v2.5 factories.
 - Wrapper sweep authority now resolves the live market borrower, and wrapper sanctions checks resolve the live market principal. Hooks and role providers do not move implicitly with a market transfer.
-- Added borrower transfer events and v2.5 lens fields for principal, pending borrower, and identity-registry discovery. See [Borrower Identity and Transfers](./Borrower%20Identity%20and%20Transfers.md).
+- Added borrower transfer events and v2.5 lens fields for current and pending principals, pending borrower, and identity-registry discovery. See [Borrower Identity and Transfers](./Borrower%20Identity%20and%20Transfers.md).
 
 ### ERC-4626 wrapper
 

--- a/docs/Core Behavior.md
+++ b/docs/Core Behavior.md
@@ -10,7 +10,9 @@ Markets are configured with the following values:
 - `asset` - The underlying asset for the market
 - `name` - The name of the market (borrower-provided prefix + asset name)
 - `symbol` - The symbol of the market (borrower-provided prefix + asset symbol)
-- `borrower` - Address allowed to borrow from and make changes to the market
+- `borrower` - Current operational address allowed to borrow from and make changes to the market
+- `borrowerPrincipal` - Registered legal principal associated with the market and used as its lender-facing sanctions namespace
+- `borrowerIdentityRegistry` - Registry used to resolve recognized borrower accounts when a transfer is requested or accepted
 - `feeRecipient` - Recipient of protocol fees
 - `sentinel` - Chainalysis wrapper determining whether accounts are sanctioned
 - `maxTotalSupply` - The `totalSupply` at which the market will stop accepting withdrawals
@@ -34,6 +36,18 @@ V2.5 has two market implementations sharing the behavior described here:
 Everything else — collateral obligations, delinquency, withdrawals, closure — is identical between the two.
 
 Conversions between scaled and normalized amounts follow deliberate rounding directions as of v2.5; see [Scale Factor — Rounding](./Scale%20Factor.md#rounding).
+
+## Borrower Identity And Transfer
+
+v2.5 separates the operational borrower from the registered principal. Direct markets begin with `borrower == borrowerPrincipal`, while a recognized contract account may operate a market for a separately recorded principal.
+
+Only the current operational borrower can call borrower-only market functions. A future Borrower Account can therefore enforce its own delegate policy before calling the market without adding delegate logic to the market itself.
+
+Borrower changes use a two-step request and acceptance flow. The current borrower requests or cancels, and only the pending target accepts. Request and acceptance resolve the target through the borrower identity registry and apply current registration and raw sanctions checks. Acceptance changes borrower identity only; market accounting and lifecycle state remain intact.
+
+The canonical ERC-4626 wrapper follows the market's live borrower and principal. Hooks and role providers do not transfer implicitly because they may be shared across markets and have separate authority domains.
+
+See [Borrower Identity and Transfers](./Borrower%20Identity%20and%20Transfers.md) for the full state model, transfer cases, events, and integration requirements.
 
 ## Basic Market Behavior
 

--- a/docs/EIP-4626.md
+++ b/docs/EIP-4626.md
@@ -107,7 +107,7 @@ Notes:
 
 #### Sanctions enforcement
 
-The wrapper reads the market’s `borrower()` and `sentinel()` at construction and uses them for sanctions checks:
+The wrapper reads the market’s current `borrowerPrincipal()` for sanctions checks and keeps only the market and sentinel addresses at construction:
 
 - ERC‑4626 entrypoints (`deposit/mint/withdraw/redeem`) check:
   - `msg.sender` (always),
@@ -116,13 +116,13 @@ The wrapper reads the market’s `borrower()` and `sentinel()` at construction a
 - ERC‑20 share transfers (`transfer/transferFrom`) revert if either `from` or `to` is sanctioned.
 - `maxDeposit/maxMint/maxWithdraw/maxRedeem` return `0` when the relevant account is sanctioned (per ERC‑4626 expectations).
 
-Sanctions checks are performed via `sanctionsSentinel.isSanctioned(marketOwner, account)`.
+Sanctions checks are performed via `sanctionsSentinel.isSanctioned(borrowerPrincipal, account)`. Same-principal account rotation therefore preserves overrides, while principal migration starts a new namespace. Existing wrapper-share escrows remain releasable under the principal namespace they were created with.
 
 #### Sweeping stray tokens
 
-`sweep(token, to)` allows the market’s borrower (captured as `marketOwner`) to rescue arbitrary ERC‑20 balances from the wrapper:
+`sweep(token, to)` allows the market’s current operational borrower to rescue arbitrary ERC‑20 balances from the wrapper:
 
-- Only callable by `marketOwner`.
+- Authorization resolves `wrappedMarket.borrower()` at execution time, so it follows an accepted borrower transfer without a wrapper callback. `marketOwner()` remains as a dynamic compatibility getter.
 - Reverts if `to` is sanctioned.
 - For non-market tokens, sweeps the entire token balance.
 - For the wrapped market token, sweeps only the **stranded scaled surplus**:

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - [Scale Factor](./Scale%20Factor.md) - explainer for the scaling of token amounts - critical for understanding the protocol
 - [Core behavior](./Core%20Behavior.md) - most important aspects of how the protocol operates
+- [Borrower identity and transfers](./Borrower%20Identity%20and%20Transfers.md) - operational borrower, legal principal, account registry, and two-step transfers in v2.5
 - [Terminology](./Terminology.md)
 - [Known issues](./Known%20Issues.md) - list of some things we know are issues or which might seem like issues but are intentional
 - [Changelog](./CHANGELOG.md) - changes between V1, V2, and V2.5

--- a/docs/Terminology.md
+++ b/docs/Terminology.md
@@ -25,7 +25,7 @@ description: It's dangerous to go alone - learn these.
 
 #### **Borrower Account**
 
-* A contract account permanently associated with one [borrower principal](Terminology.md#borrower-principal) through the borrower identity registry.
+* A contract account associated with one current [borrower principal](Terminology.md#borrower-principal) through the borrower identity registry. The principal may change through a two-step transfer.
 * May be the [operational borrower](Terminology.md#operational-borrower) for one or more markets.
 * A principal may have several accounts. Delegate policy belongs to the account, not to the market or identity registry.
 

--- a/docs/Terminology.md
+++ b/docs/Terminology.md
@@ -20,7 +20,21 @@ description: It's dangerous to go alone - learn these.
 
 * Both:
   * The counterparty that wishes to make use of a credit facility through a Wildcat [market](Terminology.md#market), and
-  * The blockchain address that defines the parameters of a market and deploys [hooks instances](Terminology.md#hooks_instance) and market contracts that use them.
+  * In older or informal usage, the blockchain address that operates a market.
+* In v2.5 contract interfaces, distinguish the [operational borrower](Terminology.md#operational-borrower) from the [borrower principal](Terminology.md#borrower-principal) instead of assuming they are always the same address.
+
+#### **Borrower Account**
+
+* A contract account permanently associated with one [borrower principal](Terminology.md#borrower-principal) through the borrower identity registry.
+* May be the [operational borrower](Terminology.md#operational-borrower) for one or more markets.
+* A principal may have several accounts. Delegate policy belongs to the account, not to the market or identity registry.
+
+#### **Borrower Principal**
+
+* The registered legal borrower identity associated with a v2.5 market.
+* Returned by `market.borrowerPrincipal()`.
+* Used as the lender-facing sanctions and new-escrow namespace.
+* May differ from the [operational borrower](Terminology.md#operational-borrower) when a recognized contract account operates the market.
 
 #### **Capacity**
 
@@ -131,6 +145,12 @@ description: It's dangerous to go alone - learn these.
 * Can only be redeemed by authorised lender addresses (not necessarily the same one that received the market tokens initially).
 * Name and symbol prefixes are customisable in market creation, prepending to the name and symbol of the underlying asset.
 
+#### **Operational Borrower**
+
+* The exact address returned by `market.borrower()` and authorized for borrower-only market actions.
+* May be the registered [borrower principal](Terminology.md#borrower-principal) directly or a recognized [Borrower Account](Terminology.md#borrower-account).
+* Can change through the v2.5 two-step borrower-transfer flow without moving or resetting market accounting state.
+
 #### **Outstanding Supply**
 
 * The amount of market tokens not currently queued for withdrawal.
@@ -226,4 +246,3 @@ description: It's dangerous to go alone - learn these.
 * The request is recorded as a scaled amount. Those scaled tokens are removed from the lender's balance immediately, but remain in the market's total supply until liquidity is reserved to pay the batch.
 * When liquidity is reserved for a batch, the corresponding scaled [market tokens](Terminology.md#market-token) are burned and the underlying assets are moved to the [unclaimed withdrawals pool](Terminology.md#unclaimed-withdrawals-pool), to be [claimed](Terminology.md#claim) after expiry.
 * Any amount requested - whether or not it is in excess of the market reserves - is marked as a [pending withdrawal](Terminology.md#pending-withdrawal), either to be fully honoured at the end of the cycle, or marked as [expired](Terminology.md#expired-withdrawal) and added to the [withdrawal queue](Terminology.md#withdrawal-queue), depending on the actions of the [borrower](Terminology.md#borrower) during the cycle.
-

--- a/docs/anvil-v2-5-rehearsal.md
+++ b/docs/anvil-v2-5-rehearsal.md
@@ -2,7 +2,7 @@
 
 This is the canonical from-scratch rehearsal for the v2.5 Sepolia EOA
 ceremony. It rebuilds the protocol and deployment artifacts, forks current
-Sepolia state, regenerates the 38-card plan, executes it through a
+Sepolia state, regenerates the 39-card plan, executes it through a
 digest-locked production build of `deploy-ui`, finalizes the local inventory,
 and exercises the canary and handoff paths.
 
@@ -14,16 +14,18 @@ any existing `deployments/anvil/` directory and kills an Anvil process matching
 the selected port before it starts. Preserve anything valuable and use an
 otherwise-unused port.
 
-At the time this walkthrough was written, the reviewed protocol source was
-`v2-protocol@bcab762` and the expected Sepolia-shaped plan was:
+The last completed fork rehearsal used `v2-protocol@bcab762` and a 38-card
+plan. The borrower identity registry adds one deployment before the markets, so
+the current Sepolia-shaped plan must have:
 
-- 38 transactions: 12 deployments and 26 calls;
+- 39 transactions: 13 deployments and 26 calls;
 - card 1: helper `returnOwnership()`;
-- cards 16-21: OpenTerm, FixedTerm, and PeriodicTerm registered on both the
+- card 3: borrower identity registry deployment;
+- cards 17-22: OpenTerm, FixedTerm, and PeriodicTerm registered on both the
   standard and revolving factories;
-- cards 24-37: paired controller-factory/controller removal for seven
+- cards 25-38: paired controller-factory/controller removal for seven
   superseded factories;
-- card 38: `transferOwnership(helper)`; and
+- card 39: `transferOwnership(helper)`; and
 - no market-removal call.
 
 Do not reuse those facts as a substitute for inspecting the newly generated
@@ -35,10 +37,10 @@ The rehearsal passes only when all of the following are true:
 
 - the full protocol test suite passes from a clean IR build;
 - the deploy-profile release source builds from a clean deploy cache;
-- the generated Anvil plan validates and has the reviewed 38-card shape;
+- the generated Anvil plan validates and has the reviewed 39-card shape;
 - Anvil is pinned to one recorded Sepolia block, uses only the explicitly
   selected archive endpoint, and writes a periodic recovery snapshot;
-- the locked UI accepts the embedded package and all 38 predicates turn green;
+- the locked UI accepts the embedded package and all 39 predicates turn green;
 - a page reload resumes from verified on-chain state;
 - the exported run-state passes independent CLI verification;
 - inventory finalization, validation, lint, and reconciliation are green;
@@ -60,7 +62,7 @@ Stop and preserve the fork if any of these occurs:
 - the connected wallet is not the exact plan executor;
 - a transaction reverts or a predicate remains red;
 - the UI reports a package/hash mismatch or a fatal halt;
-- ownership is not back with the helper after card 38; or
+- ownership is not back with the helper after card 39; or
 - independent run-state verification fails.
 
 Do not skip a card, edit the plan/package/run-state, clear browser storage, or
@@ -313,8 +315,8 @@ jq -e '
   .network == "anvil" and
   .chainId == 31337 and
   .release == "v2-5" and
-  (.transactions | length) == 38 and
-  ([.transactions[] | select(.kind == "deploy")] | length) == 12 and
+  (.transactions | length) == 39 and
+  ([.transactions[] | select(.kind == "deploy")] | length) == 13 and
   ([.transactions[] | select(.kind == "call")] | length) == 26 and
   .transactions[0].id == "reclaim-arch-controller-ownership" and
   .transactions[0].functionSignature == "returnOwnership()" and
@@ -445,7 +447,7 @@ cast nonce "$EXPECTED_EXECUTOR" --block pending --rpc-url "$RPC_URL"
 The values must match. Do not send unrelated wallet transactions during the
 ceremony.
 
-## 9. Walk all 38 cards
+## 9. Walk all 39 cards
 
 Connect the exact executor and confirm the UI shows:
 
@@ -453,7 +455,7 @@ Connect the exact executor and confirm the UI shows:
 - network `anvil`, chain `31337`;
 - release `v2-5`;
 - the recorded package fingerprint; and
-- 38 plan transactions.
+- 39 plan transactions.
 
 Then execute one card at a time. For every card:
 
@@ -470,16 +472,16 @@ Use these checkpoints:
 | After card | Expected state | Operator action |
 | --- | --- | --- |
 | 1 | Executor temporarily owns ArchController | Export and rename a checkpoint run-state. |
-| 13 | All 12 release contracts deployed | Export, rename, then reload the page and prove resume. |
-| 23 | Six templates added and both new factories registered | Export and rename a checkpoint. |
-| 37 | Seven superseded factories removed from both roles | Export before the compensating ownership return. |
-| 38 | Helper owns ArchController again | Export the final run-state. |
+| 14 | All 13 release contracts deployed | Export, rename, then reload the page and prove resume. |
+| 24 | Six templates added and both new factories registered | Export and rename a checkpoint. |
+| 38 | Seven superseded factories removed from both roles | Export before the compensating ownership return. |
+| 39 | Helper owns ArchController again | Export the final run-state. |
 
 The browser always downloads `run-state-v2-5.json`; rename intermediate files
 with their card number so they do not overwrite or obscure the final export.
 
-The reload after card 13 is part of acceptance. The page must re-read prior
-receipts/predicates and resume at card 14 without asking for a different plan.
+The reload after card 14 is part of acceptance. The page must re-read prior
+receipts/predicates and resume at card 15 without asking for a different plan.
 On that intentional reload, choose **Resume same Anvil fork**; completion and
 green card state must remain withheld until re-verification finishes.
 
@@ -543,7 +545,7 @@ cp /absolute/path/to/downloaded/run-state-v2-5.json "$RUN_STATE"
 Verify cardinality and receipt provenance through the independent CLI:
 
 ```bash
-test "$(jq 'length' "$RUN_STATE")" = "38"
+test "$(jq 'length' "$RUN_STATE")" = "39"
 
 node scripts/plan.js verify \
   --plan "$PLAN" \
@@ -586,7 +588,7 @@ the seven superseded factories must be unregistered but their historical
 
 ## 12. Run the standard and revolving canaries
 
-This phase is separate from the 38-card ceremony. It uses direct mode only
+This phase is separate from the 39-card ceremony. It uses direct mode only
 after inventory finalization.
 
 Use the disposable executor as the borrower and the seeded Sepolia mock token

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -132,7 +132,7 @@ This is mandatory. A targeted default-profile size build reports
 `HooksFactoryRevolving` at 24,767 runtime bytes, 191 bytes above EIP-170; a full
 default-profile build also encounters `Stack too deep`. The `deploy` profile
 uses via-IR and optimizer runs `200`, produces the creation code consumed by the
-plan, and reports `HooksFactoryRevolving` at 14,609 runtime bytes. Do not
+plan, and reports `HooksFactoryRevolving` at 14,989 runtime bytes. Do not
 substitute the default or high-run IR profile.
 
 Set the testnet execution context:
@@ -246,11 +246,11 @@ node scripts/plan.js execute \
   --private-key "$PVT_KEY_SEPOLIA"
 ```
 
-Review the summary before execution. The base rollout has 22 transactions: 12
+Review the summary before execution. The base rollout has 23 transactions: 13
 deployments and 10 calls. Step 06 adds two calls for every registered
 superseded hooks factory. Sepolia's ceremony config adds ownership reclaim and
-restore calls. With the currently reconciled inventories, mainnet produces 24
-transactions and Sepolia produces 38. `execute` writes
+restore calls. With the currently reconciled inventories, mainnet produces 25
+transactions and Sepolia produces 39. `execute` writes
 `deployments/<network>/run-state-v2-5.json` after receipts and predicates.
 
 ### 08 — finalize inventory
@@ -462,10 +462,12 @@ node scripts/generate-handoff.js --network mainnet --release v2-5 --check
 Deliver `handoff-v2-5.json` and `handoff-v2-5.md` with the verified ABIs to the
 subgraph and SDK owners.
 
-Current local rehearsal record: the corrected six-registration and
-superseded-factory deactivation plan completed end to end on both forks—38
-transactions and 38/38 predicates on Sepolia, 24 transactions and 24/24
-predicates on mainnet—with inventory finalization and reconciliation green.
+Previous local rehearsal record: before the borrower identity registry was
+added to the plan, the corrected six-registration and superseded-factory
+deactivation plan completed end to end on both forks—38 transactions and 38/38
+predicates on Sepolia, 24 transactions and 24/24 predicates on mainnet—with
+inventory finalization and reconciliation green. The current 39/25-transaction
+plans still need a fresh rehearsal.
 The finalized fork inventories retained historical `indexed` flags, marked all
 superseded factories unregistered, and the plans contained no market-removal
 calls. Earlier rehearsals also closed both canary markets. These generated
@@ -502,7 +504,7 @@ Every fork rehearsal must preserve these invariants:
 - generate the plan from the source revision under review with
   `FOUNDRY_PROFILE=deploy` rather than reusing generated output;
 - for the Sepolia-shaped UI path, authorize a disposable Anvil EOA in the
-  helper and keep reclaim/restore as cards 1 and 38;
+  helper and keep reclaim/restore as the first and final cards;
 - require six template registrations, paired removal of both roles for all
   seven reconciled superseded factories, and no market removal;
 - finalize only from the unedited, independently verified run-state;

--- a/docs/v2.5-audit-delta.md
+++ b/docs/v2.5-audit-delta.md
@@ -41,7 +41,7 @@ evidence backs the current state.
 | `src/libraries/MarketEvents.sol` | Removed stale sanctioned-assets-sent-to-escrow emitter. | `7088858`, CAF-03 cleanup | comment/style |
 | `src/libraries/MarketState.sol` | Added `scaleAmountDown` and `maxScaledSettleableAmount`; removed the now-unused half-up `scaleAmount`; `withdrawableProtocolFees` now saturates if unclaimed withdrawals exceed assets. | RCF merge; v2.5 rounding; footgun removal | behavioral |
 | `src/market/WildcatMarket.sol` | Deposits floor normalized-to-scaled conversion; borrow/repay/close made virtual and call new extension hooks; close liquidity subtraction made saturating; sanctioned nuke path documented as ordinary withdrawal queue; borrow now checks the raw sanctions status of both operational borrower and principal. | RCF; CR-02; v2.5 rounding; CAF-03; borrower transfer | behavioral + new-code |
-| `src/market/WildcatMarketBase.sol` | Version returns `2.5`; added `scaledTransferRounding()` marker; `withdrawableProtocolFees()` gets `nonReentrantView`; added virtual seams; state accrual dispatches `_updateScaleFactorAndFees`; batch payments floor liquidity scaling and no-op on zero scaled burn; borrower moved from immutable to namespaced storage; added stored principal, identity-registry discovery, request/cancel/accept transfer state, acceptance-time resolution, and raw sanctions checks. | v2.5 rounding; RCF; CAF-09; CR-07; borrower transfer | behavioral + new-code |
+| `src/market/WildcatMarketBase.sol` | Version returns `2.5`; added `scaledTransferRounding()` marker; `withdrawableProtocolFees()` gets `nonReentrantView`; added virtual seams; state accrual dispatches `_updateScaleFactorAndFees`; batch payments floor liquidity scaling and no-op on zero scaled burn; borrower moved from immutable to namespaced storage; added stored principal, identity-registry discovery, request/cancel/accept transfer state, pending-principal binding, same-account principal updates, acceptance-time resolution, and raw sanctions checks. | v2.5 rounding; RCF; CAF-09; CR-07; borrower transfer | behavioral + new-code |
 | `src/market/WildcatMarketConfig.sol` | Factored APR/reserve validation/write helper; added permissionless periodic APR-reduction execution gated by new hook flag; unchanged reserve ratio is re-applied with old-ratio reserve check. | `aa6d51d`, `04e6bc6`, CR-03 | behavioral + new-code |
 | `src/market/WildcatMarketRevolving.sol` | New revolving market: commitment fee immutable, `_drawnAmount`, borrow/repay/close overrides, drawn-principal clamp, and custom interest accrual: commitment on supply plus APR on `min(drawnAmount,totalSupply)`. | RCF feature; CR-02; CR-07 | new-code |
 | `src/market/WildcatMarketToken.sol` | Transfer scaling changed to `scaleAmountDown`; comments added. | v2.5 rounding | behavioral + comment/style |
@@ -89,11 +89,11 @@ Post-review additions (rounding-interaction fixes, staged):
 
 - `src/WildcatSanctionsSentinel.sol`: [comment/style] removes one stale salt comment; no behavioral source change.
 
-- `src/WildcatBorrowerIdentityRegistry.sol` and `src/interfaces/IBorrowerIdentityRegistry.sol`: [new-code] dedicated account-factory allowlist; immutable account-to-principal and factory attribution; principal/factory enumeration; direct-principal and account resolution with current ArchController registration; fail-closed unknown and ambiguous identity handling. The registry has no execution path into markets or assets.
+- `src/WildcatBorrowerIdentityRegistry.sol` and `src/interfaces/IBorrowerIdentityRegistry.sol`: [new-code] dedicated account-factory allowlist; borrower-controlled two-step account principal transfer; permanent factory attribution; current-principal and factory enumeration; direct-principal and account resolution with current ArchController registration; fail-closed unknown and ambiguous identity handling. The registry has no execution path into markets or assets.
 
 - `src/interfaces/IMarketEventsAndErrors.sol`: [behavioral/interface] removes stale buyback errors and old sanctions escrow event; adds APR-reduction errors and current sanctions withdrawal/escrow events; adds borrower-transfer errors and request/cancel/accept events with operational borrower and principal context. Log rationale: stale-code cleanup, APR-reduction public execution, and borrower transfer.
 
-- `src/lens/MarketData.sol`: [behavioral/interface] `MarketDataV2_5` adds borrower principal, pending borrower, and borrower identity registry while retaining the operational borrower in the nested base market data.
+- `src/lens/MarketData.sol`: [behavioral/interface] `MarketDataV2_5` adds current and pending borrower principals, pending borrower, and borrower identity registry while retaining the operational borrower in the nested base market data.
 
 - `src/vault/Wildcat4626Wrapper.sol`: [behavioral] wrapper authority and lender sanctions namespace now resolve the market's live borrower and principal. `marketOwner()` remains as a dynamic compatibility getter; sweep authority follows accepted market transfer without a callback.
 
@@ -174,15 +174,16 @@ implementations; version-string consumers (`'2.5'` keeps the first-byte
 5. Credential fallback narrowing (F4). 6. Periodic quarantine deferral (F3).
 7. Revolving markets accrue `commitmentFee + APR * min(drawn, supply)/supply`
    rather than APR on full supply.
-8. Market borrower authority is a storage-backed two-step transfer rather than an immutable deployment identity. Pending targets have no authority, acceptance revalidates identity, registration, and raw sanctions state, and transfer is available in active, delinquent, and closed markets.
-9. Markets record operational borrower separately from registered principal. Approved account factories may register immutable account-to-principal associations through the new identity registry; ordinary borrower calls continue using stored accepted identity.
+8. Market borrower authority is a storage-backed two-step transfer rather than an immutable deployment identity. Pending status grants no authority, acceptance revalidates identity, registration, and raw sanctions state, and transfer is available in active, delinquent, and closed markets.
+9. Markets record operational borrower separately from registered principal. Approved account factories register each account once through the new identity registry. Account principals may transfer their association through a two-step path, while each market continues using its stored accepted identity until that market explicitly accepts the new principal.
 10. Lender-facing sanctions checks use the market principal, raw borrower/principal checks gate draws and transfers, and wrapper authority follows live market identity. Hooks and providers do not move implicitly with a market transfer.
 
 ## 5. Evidence
 
-- Current full suite after the borrower-transfer feature checkpoint: 65 suites, 1,404 tests, 0 failures, 0 skipped.
+- Current full suite after the borrower-account principal-transfer correction: 65 suites, 1,423 tests, 0 failures, 0 skipped.
+- Borrower-identity registry coverage includes principal-transfer request, replacement, cancellation, acceptance, authority handoff, factory removal, current-principal removal, target revalidation, and current-principal enumeration.
 - Borrower-transfer coverage includes direct and account identities, same-principal rotation, principal migration, request replacement/cancellation, acceptance-time registration and sanctions changes, active/delinquent/closed accounting snapshots, revolving drawn-amount preservation, wrapper authority, sanctions namespaces, and v2.5 lens output.
-- Deploy-profile runtime sizes at the checkpoint: `WildcatMarket` 21,908 bytes, `WildcatMarketRevolving` 22,516 bytes, `MarketLensCore` 19,711 bytes, `MarketLensAggregator` 20,300 bytes, and `WildcatBorrowerIdentityRegistry` 3,862 bytes. All remain below the 24,576-byte EIP-170 limit.
+- Deploy-profile runtime sizes after the borrower-account principal-transfer correction: `WildcatMarket` 22,534 bytes, `WildcatMarketRevolving` 23,142 bytes, `MarketLensCore` 19,814 bytes, `MarketLensAggregator` 20,415 bytes, and `WildcatBorrowerIdentityRegistry` 5,172 bytes. All remain below the 24,576-byte EIP-170 limit.
 - Stateful fuzz: matrix invariants 18/18 at 10,000 runs x depth 100
   (pre-fix baseline) and at 5,000 x 100 with zero stranding tolerance
   (post-fix); CAF12 invariants 8/8 at 10,000 x 100; full suite at 10,000

--- a/docs/v2.5-audit-delta.md
+++ b/docs/v2.5-audit-delta.md
@@ -1,8 +1,8 @@
 # v2.5 Consolidated Pre-Audit Delta
 
 Baseline: branch `main` (the deployed, audited v2 protocol).
-Candidate: `release/v2.5` HEAD plus the rounding-interaction fixes staged for commit.
-Scope: `git diff main HEAD -- src/` — 47 files, ~4,000 insertions over 65 commits.
+Candidate: `feat/v2.5-remaining-features` at `7b32b8b`.
+Scope: `git diff main...7b32b8b -- src/` — 53 files, 4,918 insertions and 357 deletions over 112 commits.
 
 This document consolidates three independent review streams run over the full
 delta as a single artifact: two per-subsystem correctness reviews (codex), one
@@ -13,11 +13,7 @@ evidence backs the current state.
 
 ## 1. Executive summary
 
-- Three features: **revolving credit markets** (WildcatMarketRevolving +
-  HooksFactoryRevolving), **periodic-term hooks** (recurring withdrawal
-  windows + proposed/permissionless APR reductions), and a **lens rework**
-  (facade + helper contracts, with a v2.5 ABI that includes the periodic
-  pending-APR-reduction execution flag).
+- Four release areas: **revolving credit markets** (WildcatMarketRevolving + HooksFactoryRevolving), **periodic-term hooks** (recurring withdrawal windows + proposed/permissionless APR reductions), a **lens rework** (facade + helper contracts, with a v2.5 ABI that includes the periodic pending-APR-reduction execution flag), and **borrower identity and transfer** (operational borrower/principal separation, account registry, two-step market transfer, principal-aware sanctions, and transfer-aware wrapper authority).
 - One deliberate hardening with protocol-wide reach: transfer/deposit/
   withdrawal scaling changed from half-up (`rayDiv`/`scaleAmount`) to
   **floor** (`scaleAmountDown`). Every regression found in this review
@@ -31,6 +27,7 @@ evidence backs the current state.
 - The 4626 wrapper was rebuilt for floor-rounding markets and its factory is
   now a generation-routing facade; covered by its own review cycle and the
   EIP-4626 audit-scope note.
+- The borrower-transfer feature series is implemented and has passed the full test suite and deploy-profile size checks. The prior coverage appendix predates this feature series and must be refreshed before the final audit handoff.
 
 ## 2. Change inventory
 
@@ -43,8 +40,8 @@ evidence backs the current state.
 | `src/libraries/MarketErrors.sol` | Added APR-reduction errors; removed stale buyback errors; fixed APR error comment. | `aa6d51d`, CR-03; RCF merge; style | new-code + comment/style |
 | `src/libraries/MarketEvents.sol` | Removed stale sanctioned-assets-sent-to-escrow emitter. | `7088858`, CAF-03 cleanup | comment/style |
 | `src/libraries/MarketState.sol` | Added `scaleAmountDown` and `maxScaledSettleableAmount`; removed the now-unused half-up `scaleAmount`; `withdrawableProtocolFees` now saturates if unclaimed withdrawals exceed assets. | RCF merge; v2.5 rounding; footgun removal | behavioral |
-| `src/market/WildcatMarket.sol` | Deposits floor normalized-to-scaled conversion; borrow/repay/close made virtual and call new extension hooks; close liquidity subtraction made saturating; sanctioned nuke path documented as ordinary withdrawal queue. | RCF; CR-02; v2.5 rounding; CAF-03 | behavioral + new-code |
-| `src/market/WildcatMarketBase.sol` | Version returns `2.5`; added `scaledTransferRounding()` marker; `withdrawableProtocolFees()` gets `nonReentrantView`; added virtual seams; state accrual dispatches `_updateScaleFactorAndFees`; batch payments floor liquidity scaling and no-op on zero scaled burn. | v2.5 rounding; RCF; CAF-09; CR-07 | behavioral + new-code |
+| `src/market/WildcatMarket.sol` | Deposits floor normalized-to-scaled conversion; borrow/repay/close made virtual and call new extension hooks; close liquidity subtraction made saturating; sanctioned nuke path documented as ordinary withdrawal queue; borrow now checks the raw sanctions status of both operational borrower and principal. | RCF; CR-02; v2.5 rounding; CAF-03; borrower transfer | behavioral + new-code |
+| `src/market/WildcatMarketBase.sol` | Version returns `2.5`; added `scaledTransferRounding()` marker; `withdrawableProtocolFees()` gets `nonReentrantView`; added virtual seams; state accrual dispatches `_updateScaleFactorAndFees`; batch payments floor liquidity scaling and no-op on zero scaled burn; borrower moved from immutable to namespaced storage; added stored principal, identity-registry discovery, request/cancel/accept transfer state, acceptance-time resolution, and raw sanctions checks. | v2.5 rounding; RCF; CAF-09; CR-07; borrower transfer | behavioral + new-code |
 | `src/market/WildcatMarketConfig.sol` | Factored APR/reserve validation/write helper; added permissionless periodic APR-reduction execution gated by new hook flag; unchanged reserve ratio is re-applied with old-ratio reserve check. | `aa6d51d`, `04e6bc6`, CR-03 | behavioral + new-code |
 | `src/market/WildcatMarketRevolving.sol` | New revolving market: commitment fee immutable, `_drawnAmount`, borrow/repay/close overrides, drawn-principal clamp, and custom interest accrual: commitment on supply plus APR on `min(drawnAmount,totalSupply)`. | RCF feature; CR-02; CR-07 | new-code |
 | `src/market/WildcatMarketToken.sol` | Transfer scaling changed to `scaleAmountDown`; comments added. | v2.5 rounding | behavioral + comment/style |
@@ -80,11 +77,11 @@ Post-review additions (rounding-interaction fixes, staged):
 
 - `src/access/ProviderStructs.sol`: [comment/style] role-provider input comment wording only.
 
-- `src/HooksFactory.sol`: [behavioral] paginated getters now return an empty array for boundary-empty pages after clamping; [behavioral] market deployment now verifies `create2WithStoredInitCode` returned the predicted market address and can revert `MarketDeploymentAddressMismatch`; [behavioral] `pushProtocolFeeBipsUpdates` now clamps end, reverts `InvalidPaginationRange` on `start > end`, and no-ops on `start == end`. Log rationale: HooksFactory hardening and CR-06 pagination cleanup.
+- `src/HooksFactory.sol`: [behavioral] paginated getters now return an empty array for boundary-empty pages after clamping; [behavioral] market deployment now verifies `create2WithStoredInitCode` returned the predicted market address and can revert `MarketDeploymentAddressMismatch`; [behavioral] `pushProtocolFeeBipsUpdates` now clamps end, reverts `InvalidPaginationRange` on `start > end`, and no-ops on `start == end`; [behavioral] the factory stores the borrower identity registry and threads direct deployments through as `borrower == borrowerPrincipal`. Log rationale: HooksFactory hardening, CR-06 pagination cleanup, and borrower identity.
 
 - `src/IHooksFactory.sol`: [behavioral/interface] declares `MarketDeploymentAddressMismatch` and `InvalidPaginationRange`; [comment/style] clarifies pagination `end`, `onCreateMarket`, and fee-push docs. Log rationale: hardening, ambiguous `len`, style/stale cleanup.
 
-- `src/HooksFactoryRevolving.sol`: [new-code] revolving-market factory copied from `HooksFactory` with intentional RCF extensions. It deploys markets from revolving init code, decodes factory-owned `marketData` as version plus `commitmentFeeBips`, validates fee bips, and stores commitment fee in transient deployment data. It exposes `getRevolvingMarketCommitmentFeeBips()` for the revolving market constructor. It preserves template/instance registries, origination fees, borrower checks, salts, blacklist checks, `onCreateMarket`, CREATE2 address verification, market indexing, and protocol-fee push pagination. Log rationale: RCF merge, `create2WithStoredInitCode`, CR-06 pagination, gas/docs/code-dedup.
+- `src/HooksFactoryRevolving.sol`: [new-code] revolving-market factory copied from `HooksFactory` with intentional RCF extensions. It deploys markets from revolving init code, decodes factory-owned `marketData` as version plus `commitmentFeeBips`, validates fee bips, and stores commitment fee in transient deployment data. It exposes `getRevolvingMarketCommitmentFeeBips()` for the revolving market constructor. It preserves template/instance registries, origination fees, borrower checks, salts, blacklist checks, `onCreateMarket`, CREATE2 address verification, market indexing, and protocol-fee push pagination. Like the standard factory, it stores the borrower identity registry and initializes direct markets with matching borrower/principal identity. Log rationale: RCF merge, `create2WithStoredInitCode`, CR-06 pagination, gas/docs/code-dedup, and borrower identity.
 
 - `src/IHooksFactoryRevolving.sol`: [new-code] revolving factory interface with market-data errors, commitment-fee getter, and deploy functions carrying `marketData`.
 
@@ -92,7 +89,13 @@ Post-review additions (rounding-interaction fixes, staged):
 
 - `src/WildcatSanctionsSentinel.sol`: [comment/style] removes one stale salt comment; no behavioral source change.
 
-- `src/interfaces/IMarketEventsAndErrors.sol`: [behavioral/interface] removes stale buyback errors and old sanctions escrow event; adds APR-reduction errors and current sanctions withdrawal/escrow events. Log rationale: stale-code cleanup and APR-reduction public execution.
+- `src/WildcatBorrowerIdentityRegistry.sol` and `src/interfaces/IBorrowerIdentityRegistry.sol`: [new-code] dedicated account-factory allowlist; immutable account-to-principal and factory attribution; principal/factory enumeration; direct-principal and account resolution with current ArchController registration; fail-closed unknown and ambiguous identity handling. The registry has no execution path into markets or assets.
+
+- `src/interfaces/IMarketEventsAndErrors.sol`: [behavioral/interface] removes stale buyback errors and old sanctions escrow event; adds APR-reduction errors and current sanctions withdrawal/escrow events; adds borrower-transfer errors and request/cancel/accept events with operational borrower and principal context. Log rationale: stale-code cleanup, APR-reduction public execution, and borrower transfer.
+
+- `src/lens/MarketData.sol`: [behavioral/interface] `MarketDataV2_5` adds borrower principal, pending borrower, and borrower identity registry while retaining the operational borrower in the nested base market data.
+
+- `src/vault/Wildcat4626Wrapper.sol`: [behavioral] wrapper authority and lender sanctions namespace now resolve the market's live borrower and principal. `marketOwner()` remains as a dynamic compatibility getter; sweep authority follows accepted market transfer without a callback.
 
 - `src/interfaces/IWildcatMarketRevolving.sol`: [new-code] minimal revolving market view interface for `commitmentFeeBips()` and `drawnAmount()`.
 
@@ -171,29 +174,29 @@ implementations; version-string consumers (`'2.5'` keeps the first-byte
 5. Credential fallback narrowing (F4). 6. Periodic quarantine deferral (F3).
 7. Revolving markets accrue `commitmentFee + APR * min(drawn, supply)/supply`
    rather than APR on full supply.
+8. Market borrower authority is a storage-backed two-step transfer rather than an immutable deployment identity. Pending targets have no authority, acceptance revalidates identity, registration, and raw sanctions state, and transfer is available in active, delinquent, and closed markets.
+9. Markets record operational borrower separately from registered principal. Approved account factories may register immutable account-to-principal associations through the new identity registry; ordinary borrower calls continue using stored accepted identity.
+10. Lender-facing sanctions checks use the market principal, raw borrower/principal checks gate draws and transfers, and wrapper authority follows live market identity. Hooks and providers do not move implicitly with a market transfer.
 
 ## 5. Evidence
 
-- Full suite: 1,163 tests, 0 failures (includes 60+ integration tests over
-  the {Open,Fixed,Periodic} x {Standard,Revolving} matrix with a
-  closed-form interest oracle covering delinquency penalties).
+- Current full suite after the borrower-transfer feature checkpoint: 65 suites, 1,404 tests, 0 failures, 0 skipped.
+- Borrower-transfer coverage includes direct and account identities, same-principal rotation, principal migration, request replacement/cancellation, acceptance-time registration and sanctions changes, active/delinquent/closed accounting snapshots, revolving drawn-amount preservation, wrapper authority, sanctions namespaces, and v2.5 lens output.
+- Deploy-profile runtime sizes at the checkpoint: `WildcatMarket` 21,908 bytes, `WildcatMarketRevolving` 22,516 bytes, `MarketLensCore` 19,711 bytes, `MarketLensAggregator` 20,300 bytes, and `WildcatBorrowerIdentityRegistry` 3,862 bytes. All remain below the 24,576-byte EIP-170 limit.
 - Stateful fuzz: matrix invariants 18/18 at 10,000 runs x depth 100
   (pre-fix baseline) and at 5,000 x 100 with zero stranding tolerance
   (post-fix); CAF12 invariants 8/8 at 10,000 x 100; full suite at 10,000
   fuzz runs, 0 counterexamples.
-- Coverage: 95.6% lines / 80.6% branches over src/ (procedure in
-  docs/BACKLOG.md; requires the coverage-spherex patch).
+- The most recent coverage run predates the borrower-transfer feature. Its historical result and uncovered-branch inventory remain below, but they are not current coverage evidence for the new registry or transfer paths. The final coverage run still requires the documented SphereX workaround.
 - Arithmetic proofs: 10/10 items proven for the F1/F2 fixes (exact-integer
   search, edge sweeps at sf = RAY, uint112.max, 1-wei amounts, uint104
   boundaries).
 - Reviews: 2x codex subsystem passes, 3x multi-agent interaction/fix passes
   (31, 15 agents), all findings resolved or explicitly accepted above.
 
-## 6. Coverage appendix: enumerated uncovered branches
+## 6. Pre-transfer coverage appendix: enumerated uncovered branches
 
-Final coverage: **98.35% lines, 96.32% branches** (498/517) over `src/`,
-1,298 tests. Every uncovered branch is enumerated and justified below; there
-is no unexamined dark territory. Categories: **[D]** deployment-time only,
+The previous checkpoint measured **98.35% lines, 96.32% branches** (498/517) over `src/` with 1,298 tests. It predates the borrower-transfer feature and must not be presented as final coverage for the current candidate. At that checkpoint, every uncovered branch was enumerated and justified below. Categories: **[D]** deployment-time only,
 **[P]** proven unreachable (arithmetic identity or dominating guard),
 **[E]** external-dependency revert-side (documented in Known Issues),
 **[U]** unused library-completeness overload, **[A]** instrumentation
@@ -216,7 +219,4 @@ attribution artifact (both behaviors asserted by passing tests).
 
 ## 7. Deferred (docs/BACKLOG.md)
 
-v2.5 deployment scripts (incl. 4626 facade wiring), prettier-plugin upgrade,
-lens Core/Live unused immutables, hoisting the tripled minimum-deposit check
-into MarketConstraintHooks, removal of the now-unused half-up
-`MarketState.scaleAmount` and its unit test.
+Final v2.5 ceremony regeneration after the remaining feature hard cut, removal of the deprecated v2.1 periodic deployment script, prettier-plugin upgrade, lens Core/Live unused immutables, and hoisting the tripled minimum-deposit check into MarketConstraintHooks.

--- a/script/deploy/v2-5/02-deploy-hooks-factory-standard.s.sol
+++ b/script/deploy/v2-5/02-deploy-hooks-factory-standard.s.sol
@@ -19,17 +19,22 @@ pragma solidity >=0.8.20;
 import { console } from 'forge-std/console.sol';
 
 import { IHooksFactory } from 'src/IHooksFactory.sol';
+import { IBorrowerIdentityRegistry } from 'src/interfaces/IBorrowerIdentityRegistry.sol';
 
 import '../../common/DeployScriptBase.sol';
 
 contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
   string internal constant MARKET_ARTIFACT = 'src/market/WildcatMarket.sol:WildcatMarket';
   string internal constant FACTORY_ARTIFACT = 'src/HooksFactory.sol:HooksFactory';
+  string internal constant IDENTITY_REGISTRY_ARTIFACT =
+    'src/WildcatBorrowerIdentityRegistry.sol:WildcatBorrowerIdentityRegistry';
   string internal constant INIT_CODE_STORAGE_ARTIFACT =
     'script/common/DeployScriptBase.sol:InitCodeStorage';
 
   string internal constant WRAPPER_ENTRY_ID = 'deploy-wildcat-4626-wrapper-factory';
   string internal constant WRAPPER_OUTPUT = 'wildcat-4626-wrapper-factory';
+  string internal constant IDENTITY_REGISTRY_ENTRY_ID = 'deploy-borrower-identity-registry';
+  string internal constant IDENTITY_REGISTRY_OUTPUT = 'borrower-identity-registry';
   string internal constant STORAGE_ENTRY_ID = 'deploy-wildcat-market-init-code-storage';
   string internal constant STORAGE_OUTPUT = 'wildcat-market-init-code-storage';
   string internal constant FACTORY_ENTRY_ID = 'deploy-hooks-factory-standard';
@@ -49,6 +54,7 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
     address archController,
     address sanctionsSentinel,
     address wrapperFactory,
+    address borrowerIdentityRegistry,
     address initCodeStorage,
     uint256 initCodeHash
   ) internal view {
@@ -76,6 +82,13 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
     _verifyAddressCall(
       factory,
       label,
+      'borrowerIdentityRegistry',
+      abi.encodeWithSelector(IHooksFactory.borrowerIdentityRegistry.selector),
+      borrowerIdentityRegistry
+    );
+    _verifyAddressCall(
+      factory,
+      label,
       'marketInitCodeStorage',
       abi.encodeWithSelector(IHooksFactory.marketInitCodeStorage.selector),
       initCodeStorage
@@ -93,10 +106,32 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
     Deployments memory deployments,
     DeploymentInputs memory inputs
   ) internal {
+    string[] memory registryAfter = new string[](1);
+    registryAfter[0] = WRAPPER_ENTRY_ID;
+    DeployPlanEntry memory registryEntry;
+    registryEntry.sequence = 2;
+    registryEntry.id = IDENTITY_REGISTRY_ENTRY_ID;
+    registryEntry.artifactName = IDENTITY_REGISTRY_ARTIFACT;
+    registryEntry.decodedConstructorArgs = string.concat(
+      '[',
+      _quoted(vm.toString(inputs.archController)),
+      ']'
+    );
+    registryEntry.output = IDENTITY_REGISTRY_OUTPUT;
+    registryEntry.description = 'Deploy the v2.5 borrower identity registry.';
+    registryEntry.predicate = _planCallEqPredicate(
+      IDENTITY_REGISTRY_OUTPUT,
+      'archController() view returns (address)',
+      '[]',
+      _quoted(vm.toString(inputs.archController))
+    );
+    registryEntry.afterEntries = registryAfter;
+    _planEntry(deployments, registryEntry);
+
     string[] memory storageAfter = new string[](1);
-    storageAfter[0] = WRAPPER_ENTRY_ID;
+    storageAfter[0] = IDENTITY_REGISTRY_ENTRY_ID;
     DeployPlanEntry memory storageEntry;
-    storageEntry.sequence = 2;
+    storageEntry.sequence = 3;
     storageEntry.id = STORAGE_ENTRY_ID;
     storageEntry.artifactName = INIT_CODE_STORAGE_ARTIFACT;
     storageEntry.decodedConstructorArgs = string.concat(
@@ -113,7 +148,7 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
     string[] memory factoryAfter = new string[](1);
     factoryAfter[0] = STORAGE_ENTRY_ID;
     DeployPlanEntry memory factoryEntry;
-    factoryEntry.sequence = 3;
+    factoryEntry.sequence = 4;
     factoryEntry.id = FACTORY_ENTRY_ID;
     factoryEntry.artifactName = FACTORY_ARTIFACT;
     factoryEntry.decodedConstructorArgs = string.concat(
@@ -127,6 +162,8 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       _ref(STORAGE_OUTPUT),
       ',',
       _quoted(vm.toString(bytes32(inputs.initCodeHash))),
+      ',',
+      _ref(IDENTITY_REGISTRY_OUTPUT),
       ']'
     );
     factoryEntry.output = FACTORY_OUTPUT;
@@ -146,11 +183,26 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
     string memory networkName,
     string memory storageLabel,
     address initCodeStorage,
+    string memory identityRegistryLabel,
+    address borrowerIdentityRegistry,
     string memory factoryLabel,
     address factory,
     address wrapperFactory,
     uint256 initCodeHash
   ) internal {
+    string memory identityRegistryRecord = string.concat(
+      '{"recordType":"deployment","role":"identityRegistry","network":',
+      _quoted(networkName),
+      ',"chainId":',
+      vm.toString(block.chainid),
+      ',"deploymentKey":',
+      _quoted(identityRegistryLabel),
+      ',"address":',
+      _quoted(vm.toString(borrowerIdentityRegistry)),
+      '}'
+    );
+    _inventoryRecord(deployments, 2, identityRegistryLabel, identityRegistryRecord);
+
     string memory storageRecord = string.concat(
       '{"recordType":"initCodeStorage","network":',
       _quoted(networkName),
@@ -164,7 +216,7 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       _quoted(vm.toString(bytes32(initCodeHash))),
       '}'
     );
-    _inventoryRecord(deployments, 2, storageLabel, storageRecord);
+    _inventoryRecord(deployments, 3, storageLabel, storageRecord);
 
     string memory factoryRecord = string.concat(
       '{"recordType":"hooksFactory","network":',
@@ -177,13 +229,15 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       _quoted(vm.toString(factory)),
       ',"wrapperFactory":',
       _quoted(vm.toString(wrapperFactory)),
+      ',"borrowerIdentityRegistry":',
+      _quoted(vm.toString(borrowerIdentityRegistry)),
       ',"initCodeStorage":',
       _quoted(vm.toString(initCodeStorage)),
       ',"initCodeHash":',
       _quoted(vm.toString(bytes32(initCodeHash))),
       ',"canonicalIntent":true}'
     );
-    _inventoryRecord(deployments, 3, factoryLabel, factoryRecord);
+    _inventoryRecord(deployments, 4, factoryLabel, factoryRecord);
   }
 
   function _writePlanInventoryRecords(
@@ -191,6 +245,20 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
     string memory networkName,
     uint256 initCodeHash
   ) internal {
+    string memory identityRegistryLabel = _label('WildcatBorrowerIdentityRegistry');
+    string memory identityRegistryRecord = string.concat(
+      '{"recordType":"deployment","role":"identityRegistry","network":',
+      _quoted(networkName),
+      ',"chainId":',
+      vm.toString(block.chainid),
+      ',"deploymentKey":',
+      _quoted(identityRegistryLabel),
+      ',"address":',
+      _ref(IDENTITY_REGISTRY_OUTPUT),
+      '}'
+    );
+    _inventoryRecord(deployments, 2, identityRegistryLabel, identityRegistryRecord);
+
     string memory storageLabel = _label('WildcatMarket_initCodeStorage');
     string memory storageRecord = string.concat(
       '{"recordType":"initCodeStorage","network":',
@@ -205,7 +273,7 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       _quoted(vm.toString(bytes32(initCodeHash))),
       '}'
     );
-    _inventoryRecord(deployments, 2, storageLabel, storageRecord);
+    _inventoryRecord(deployments, 3, storageLabel, storageRecord);
 
     string memory factoryLabel = _label('HooksFactory');
     string memory factoryRecord = string.concat(
@@ -219,13 +287,15 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       _ref(FACTORY_OUTPUT),
       ',"wrapperFactory":',
       _ref(WRAPPER_OUTPUT),
+      ',"borrowerIdentityRegistry":',
+      _ref(IDENTITY_REGISTRY_OUTPUT),
       ',"initCodeStorage":',
       _ref(STORAGE_OUTPUT),
       ',"initCodeHash":',
       _quoted(vm.toString(bytes32(initCodeHash))),
       ',"registerEntryId":"register-hooks-factory-standard","canonicalIntent":true}'
     );
-    _inventoryRecord(deployments, 3, factoryLabel, factoryRecord);
+    _inventoryRecord(deployments, 4, factoryLabel, factoryRecord);
   }
 
   function _runDirect(
@@ -234,8 +304,23 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
     DeploymentInputs memory inputs
   ) internal {
     _assertEip1153Supported();
+    string memory identityRegistryLabel = _label('WildcatBorrowerIdentityRegistry');
     string memory storageLabel = _label('WildcatMarket_initCodeStorage');
     string memory factoryLabel = _label('HooksFactory');
+    (address borrowerIdentityRegistry, bool didDeployIdentityRegistry) = _getOrDeployByLabel(
+      deployments,
+      identityRegistryLabel,
+      IDENTITY_REGISTRY_ARTIFACT,
+      _getCreationCode(deployments, IDENTITY_REGISTRY_ARTIFACT),
+      abi.encode(inputs.archController)
+    );
+    _verifyAddressCall(
+      borrowerIdentityRegistry,
+      identityRegistryLabel,
+      'archController',
+      abi.encodeWithSelector(IBorrowerIdentityRegistry.archController.selector),
+      inputs.archController
+    );
     (address initCodeStorage, bool didDeployStorage) = _getOrDeployInitCodeStorageByLabel(
       deployments,
       storageLabel,
@@ -247,7 +332,8 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       inputs.sanctionsSentinel,
       inputs.wrapperFactory,
       initCodeStorage,
-      inputs.initCodeHash
+      inputs.initCodeHash,
+      borrowerIdentityRegistry
     );
     bytes memory factoryCreationCode = _getCreationCode(deployments, FACTORY_ARTIFACT);
     (address factory, bool didDeployFactory) = _getOrDeployByLabel(
@@ -263,6 +349,7 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       inputs.archController,
       inputs.sanctionsSentinel,
       inputs.wrapperFactory,
+      borrowerIdentityRegistry,
       initCodeStorage,
       inputs.initCodeHash
     );
@@ -274,12 +361,15 @@ contract DeployHooksFactoryStandardV25 is V25DeployScriptBase {
       networkName,
       storageLabel,
       initCodeStorage,
+      identityRegistryLabel,
+      borrowerIdentityRegistry,
       factoryLabel,
       factory,
       inputs.wrapperFactory,
       inputs.initCodeHash
     );
 
+    console.log('Did deploy WildcatBorrowerIdentityRegistry:', didDeployIdentityRegistry);
     console.log('Did deploy WildcatMarket init-code storage:', didDeployStorage);
     console.log('Did deploy HooksFactory:', didDeployFactory);
   }

--- a/script/deploy/v2-5/03-deploy-hooks-factory-revolving.s.sol
+++ b/script/deploy/v2-5/03-deploy-hooks-factory-revolving.s.sol
@@ -31,6 +31,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
 
   string internal constant STANDARD_FACTORY_ENTRY_ID = 'deploy-hooks-factory-standard';
   string internal constant WRAPPER_OUTPUT = 'wildcat-4626-wrapper-factory';
+  string internal constant IDENTITY_REGISTRY_OUTPUT = 'borrower-identity-registry';
   string internal constant STORAGE_ENTRY_ID = 'deploy-wildcat-market-revolving-init-code-storage';
   string internal constant STORAGE_OUTPUT = 'wildcat-market-revolving-init-code-storage';
   string internal constant FACTORY_ENTRY_ID = 'deploy-hooks-factory-revolving';
@@ -40,6 +41,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
     address archController;
     address sanctionsSentinel;
     address wrapperFactory;
+    address borrowerIdentityRegistry;
     bytes marketCreationCode;
     uint256 initCodeHash;
   }
@@ -50,6 +52,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
     address archController,
     address sanctionsSentinel,
     address wrapperFactory,
+    address borrowerIdentityRegistry,
     address initCodeStorage,
     uint256 initCodeHash
   ) internal view {
@@ -77,6 +80,13 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
     _verifyAddressCall(
       factory,
       label,
+      'borrowerIdentityRegistry',
+      abi.encodeWithSelector(IHooksFactoryRevolving.borrowerIdentityRegistry.selector),
+      borrowerIdentityRegistry
+    );
+    _verifyAddressCall(
+      factory,
+      label,
       'marketInitCodeStorage',
       abi.encodeWithSelector(IHooksFactoryRevolving.marketInitCodeStorage.selector),
       initCodeStorage
@@ -97,7 +107,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
     string[] memory storageAfter = new string[](1);
     storageAfter[0] = STANDARD_FACTORY_ENTRY_ID;
     DeployPlanEntry memory storageEntry;
-    storageEntry.sequence = 4;
+    storageEntry.sequence = 5;
     storageEntry.id = STORAGE_ENTRY_ID;
     storageEntry.artifactName = INIT_CODE_STORAGE_ARTIFACT;
     storageEntry.decodedConstructorArgs = string.concat(
@@ -114,7 +124,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
     string[] memory factoryAfter = new string[](1);
     factoryAfter[0] = STORAGE_ENTRY_ID;
     DeployPlanEntry memory factoryEntry;
-    factoryEntry.sequence = 5;
+    factoryEntry.sequence = 6;
     factoryEntry.id = FACTORY_ENTRY_ID;
     factoryEntry.artifactName = FACTORY_ARTIFACT;
     factoryEntry.decodedConstructorArgs = string.concat(
@@ -128,6 +138,8 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       _ref(STORAGE_OUTPUT),
       ',',
       _quoted(vm.toString(bytes32(inputs.initCodeHash))),
+      ',',
+      _ref(IDENTITY_REGISTRY_OUTPUT),
       ']'
     );
     factoryEntry.output = FACTORY_OUTPUT;
@@ -150,6 +162,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
     string memory factoryLabel,
     address factory,
     address wrapperFactory,
+    address borrowerIdentityRegistry,
     uint256 initCodeHash
   ) internal {
     string memory storageRecord = string.concat(
@@ -165,7 +178,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       _quoted(vm.toString(bytes32(initCodeHash))),
       '}'
     );
-    _inventoryRecord(deployments, 4, storageLabel, storageRecord);
+    _inventoryRecord(deployments, 5, storageLabel, storageRecord);
 
     string memory factoryRecord = string.concat(
       '{"recordType":"hooksFactory","network":',
@@ -178,13 +191,15 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       _quoted(vm.toString(factory)),
       ',"wrapperFactory":',
       _quoted(vm.toString(wrapperFactory)),
+      ',"borrowerIdentityRegistry":',
+      _quoted(vm.toString(borrowerIdentityRegistry)),
       ',"initCodeStorage":',
       _quoted(vm.toString(initCodeStorage)),
       ',"initCodeHash":',
       _quoted(vm.toString(bytes32(initCodeHash))),
       ',"canonicalIntent":true}'
     );
-    _inventoryRecord(deployments, 5, factoryLabel, factoryRecord);
+    _inventoryRecord(deployments, 6, factoryLabel, factoryRecord);
   }
 
   function _writePlanInventoryRecords(
@@ -206,7 +221,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       _quoted(vm.toString(bytes32(initCodeHash))),
       '}'
     );
-    _inventoryRecord(deployments, 4, storageLabel, storageRecord);
+    _inventoryRecord(deployments, 5, storageLabel, storageRecord);
 
     string memory factoryLabel = _label('HooksFactoryRevolving');
     string memory factoryRecord = string.concat(
@@ -220,13 +235,15 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       _ref(FACTORY_OUTPUT),
       ',"wrapperFactory":',
       _ref(WRAPPER_OUTPUT),
+      ',"borrowerIdentityRegistry":',
+      _ref(IDENTITY_REGISTRY_OUTPUT),
       ',"initCodeStorage":',
       _ref(STORAGE_OUTPUT),
       ',"initCodeHash":',
       _quoted(vm.toString(bytes32(initCodeHash))),
       ',"registerEntryId":"register-hooks-factory-revolving","canonicalIntent":true}'
     );
-    _inventoryRecord(deployments, 5, factoryLabel, factoryRecord);
+    _inventoryRecord(deployments, 6, factoryLabel, factoryRecord);
   }
 
   function _runDirect(
@@ -248,7 +265,8 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       inputs.sanctionsSentinel,
       inputs.wrapperFactory,
       initCodeStorage,
-      inputs.initCodeHash
+      inputs.initCodeHash,
+      inputs.borrowerIdentityRegistry
     );
     bytes memory factoryCreationCode = _getCreationCode(deployments, FACTORY_ARTIFACT);
     (address factory, bool didDeployFactory) = _getOrDeployByLabel(
@@ -264,6 +282,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       inputs.archController,
       inputs.sanctionsSentinel,
       inputs.wrapperFactory,
+      inputs.borrowerIdentityRegistry,
       initCodeStorage,
       inputs.initCodeHash
     );
@@ -278,6 +297,7 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       factoryLabel,
       factory,
       inputs.wrapperFactory,
+      inputs.borrowerIdentityRegistry,
       inputs.initCodeHash
     );
 
@@ -312,6 +332,11 @@ contract DeployHooksFactoryRevolvingV25 is V25DeployScriptBase {
       deployments,
       _label('Wildcat4626WrapperFactory'),
       'WRAPPER_FACTORY'
+    );
+    inputs.borrowerIdentityRegistry = _resolveExisting(
+      deployments,
+      _label('WildcatBorrowerIdentityRegistry'),
+      'BORROWER_IDENTITY_REGISTRY'
     );
     _runDirect(deployments, networkName, inputs);
   }

--- a/script/deploy/v2-5/04-deploy-market-lens.s.sol
+++ b/script/deploy/v2-5/04-deploy-market-lens.s.sol
@@ -87,7 +87,7 @@ contract DeployMarketLensV25 is V25DeployScriptBase {
   function _writePlanEntries(Deployments memory deployments, address archController) internal {
     _writeHelperPlanEntry(
       deployments,
-      6,
+      7,
       CORE_ENTRY_ID,
       CORE_ARTIFACT,
       CORE_OUTPUT,
@@ -97,7 +97,7 @@ contract DeployMarketLensV25 is V25DeployScriptBase {
     );
     _writeHelperPlanEntry(
       deployments,
-      7,
+      8,
       AGGREGATOR_ENTRY_ID,
       AGGREGATOR_ARTIFACT,
       AGGREGATOR_OUTPUT,
@@ -107,7 +107,7 @@ contract DeployMarketLensV25 is V25DeployScriptBase {
     );
     _writeHelperPlanEntry(
       deployments,
-      8,
+      9,
       LIVE_ENTRY_ID,
       LIVE_ARTIFACT,
       LIVE_OUTPUT,
@@ -119,7 +119,7 @@ contract DeployMarketLensV25 is V25DeployScriptBase {
     string[] memory facadeAfter = new string[](1);
     facadeAfter[0] = LIVE_ENTRY_ID;
     DeployPlanEntry memory facadeEntry;
-    facadeEntry.sequence = 9;
+    facadeEntry.sequence = 10;
     facadeEntry.id = FACADE_ENTRY_ID;
     facadeEntry.artifactName = FACADE_ARTIFACT;
     facadeEntry.decodedConstructorArgs = string.concat(
@@ -284,17 +284,17 @@ contract DeployMarketLensV25 is V25DeployScriptBase {
     string memory networkName,
     LensSet memory lens
   ) internal {
-    _writeInventoryRecord(deployments, networkName, 6, 'MarketLensCore', 'core', lens.core);
+    _writeInventoryRecord(deployments, networkName, 7, 'MarketLensCore', 'core', lens.core);
     _writeInventoryRecord(
       deployments,
       networkName,
-      7,
+      8,
       'MarketLensAggregator',
       'aggregator',
       lens.aggregator
     );
-    _writeInventoryRecord(deployments, networkName, 8, 'MarketLensLive', 'live', lens.live);
-    _writeInventoryRecord(deployments, networkName, 9, 'MarketLens', 'facade', lens.facade);
+    _writeInventoryRecord(deployments, networkName, 9, 'MarketLensLive', 'live', lens.live);
+    _writeInventoryRecord(deployments, networkName, 10, 'MarketLens', 'facade', lens.facade);
   }
 
   function _writePlanInventoryRecord(
@@ -326,17 +326,17 @@ contract DeployMarketLensV25 is V25DeployScriptBase {
     Deployments memory deployments,
     string memory networkName
   ) internal {
-    _writePlanInventoryRecord(deployments, networkName, 6, 'MarketLensCore', 'core', CORE_OUTPUT);
+    _writePlanInventoryRecord(deployments, networkName, 7, 'MarketLensCore', 'core', CORE_OUTPUT);
     _writePlanInventoryRecord(
       deployments,
       networkName,
-      7,
+      8,
       'MarketLensAggregator',
       'aggregator',
       AGGREGATOR_OUTPUT
     );
-    _writePlanInventoryRecord(deployments, networkName, 8, 'MarketLensLive', 'live', LIVE_OUTPUT);
-    _writePlanInventoryRecord(deployments, networkName, 9, 'MarketLens', 'facade', FACADE_OUTPUT);
+    _writePlanInventoryRecord(deployments, networkName, 9, 'MarketLensLive', 'live', LIVE_OUTPUT);
+    _writePlanInventoryRecord(deployments, networkName, 10, 'MarketLens', 'facade', FACADE_OUTPUT);
   }
 
   function run() external {

--- a/script/deploy/v2-5/05-owner-actions.s.sol
+++ b/script/deploy/v2-5/05-owner-actions.s.sol
@@ -263,7 +263,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       networkName,
       openTerm,
-      10,
+      11,
       OPEN_STORAGE_ENTRY_ID,
       OPEN_STORAGE_OUTPUT,
       DEPLOYMENTS_COMPLETE_ENTRY_ID
@@ -272,7 +272,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       networkName,
       fixedTerm,
-      11,
+      12,
       FIXED_STORAGE_ENTRY_ID,
       FIXED_STORAGE_OUTPUT,
       OPEN_STORAGE_ENTRY_ID
@@ -281,7 +281,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       networkName,
       periodicTerm,
-      12,
+      13,
       PERIODIC_STORAGE_ENTRY_ID,
       PERIODIC_STORAGE_OUTPUT,
       FIXED_STORAGE_ENTRY_ID
@@ -290,7 +290,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
     _writeRegisterControllerFactoryPlanEntry(
       deployments,
       archController,
-      13,
+      14,
       REGISTER_STANDARD_FACTORY_ENTRY_ID,
       STANDARD_FACTORY_OUTPUT,
       PERIODIC_STORAGE_ENTRY_ID,
@@ -299,7 +299,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
     _writeRegisterControllerFactoryPlanEntry(
       deployments,
       archController,
-      14,
+      15,
       REGISTER_REVOLVING_FACTORY_ENTRY_ID,
       REVOLVING_FACTORY_OUTPUT,
       REGISTER_STANDARD_FACTORY_ENTRY_ID,
@@ -313,7 +313,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       openTerm,
       openFeeRecipient,
-      15,
+      16,
       ADD_STANDARD_OPEN_ENTRY_ID,
       STANDARD_FACTORY_OUTPUT,
       OPEN_STORAGE_OUTPUT,
@@ -324,7 +324,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       fixedTerm,
       fixedFeeRecipient,
-      16,
+      17,
       ADD_STANDARD_FIXED_ENTRY_ID,
       STANDARD_FACTORY_OUTPUT,
       FIXED_STORAGE_OUTPUT,
@@ -335,7 +335,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       periodicTerm,
       periodicFeeRecipient,
-      17,
+      18,
       ADD_STANDARD_PERIODIC_ENTRY_ID,
       STANDARD_FACTORY_OUTPUT,
       PERIODIC_STORAGE_OUTPUT,
@@ -346,7 +346,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       openTerm,
       openFeeRecipient,
-      18,
+      19,
       ADD_REVOLVING_OPEN_ENTRY_ID,
       REVOLVING_FACTORY_OUTPUT,
       OPEN_STORAGE_OUTPUT,
@@ -357,7 +357,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       fixedTerm,
       fixedFeeRecipient,
-      19,
+      20,
       ADD_REVOLVING_FIXED_ENTRY_ID,
       REVOLVING_FACTORY_OUTPUT,
       FIXED_STORAGE_OUTPUT,
@@ -368,7 +368,7 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       deployments,
       periodicTerm,
       periodicFeeRecipient,
-      20,
+      21,
       ADD_REVOLVING_PERIODIC_ENTRY_ID,
       REVOLVING_FACTORY_OUTPUT,
       PERIODIC_STORAGE_OUTPUT,
@@ -491,9 +491,9 @@ contract OwnerActionsV25 is V25DeployScriptBase {
       return;
     }
 
-    openTerm = _deployTemplateStorage(deployments, networkName, openTerm, 10);
-    fixedTerm = _deployTemplateStorage(deployments, networkName, fixedTerm, 11);
-    periodicTerm = _deployTemplateStorage(deployments, networkName, periodicTerm, 12);
+    openTerm = _deployTemplateStorage(deployments, networkName, openTerm, 11);
+    fixedTerm = _deployTemplateStorage(deployments, networkName, fixedTerm, 12);
+    periodicTerm = _deployTemplateStorage(deployments, networkName, periodicTerm, 13);
     deployments.write();
 
     string memory standardFactoryLabel = _label('HooksFactory');

--- a/script/deploy/v2-5/06-register-factories.s.sol
+++ b/script/deploy/v2-5/06-register-factories.s.sol
@@ -139,7 +139,7 @@ contract RegisterFactoriesV25 is V25DeployScriptBase {
         deployments,
         archController,
         targets[i],
-        23 + i * 2,
+        24 + i * 2,
         removeFactoryEntryId,
         afterEntry,
         true
@@ -149,7 +149,7 @@ contract RegisterFactoriesV25 is V25DeployScriptBase {
         deployments,
         archController,
         targets[i],
-        24 + i * 2,
+        25 + i * 2,
         removeControllerEntryId,
         removeFactoryEntryId,
         false
@@ -217,7 +217,7 @@ contract RegisterFactoriesV25 is V25DeployScriptBase {
       _writePlanEntry(
         deployments,
         archControllerAddress,
-        21,
+        22,
         REGISTER_STANDARD_ENTRY_ID,
         STANDARD_FACTORY_OUTPUT,
         AFTER_OWNER_ACTIONS,
@@ -226,7 +226,7 @@ contract RegisterFactoriesV25 is V25DeployScriptBase {
       _writePlanEntry(
         deployments,
         archControllerAddress,
-        22,
+        23,
         REGISTER_REVOLVING_ENTRY_ID,
         REVOLVING_FACTORY_OUTPUT,
         REGISTER_STANDARD_ENTRY_ID,

--- a/scripts/factory-inventory.js
+++ b/scripts/factory-inventory.js
@@ -1853,6 +1853,7 @@ async function runApplyRun(args) {
   let revolvingFactory = null;
   let wrapperFactory = null;
   let marketLens = null;
+  let borrowerIdentityRegistry = null;
 
   for (const fileName of pendingFiles) {
     const filePath = path.join(pendingDirectory, fileName);
@@ -1933,11 +1934,23 @@ async function runApplyRun(args) {
     if (record.recordType === "deployment" && record.role === "facade") {
       marketLens = record.address;
     }
+    if (
+      record.recordType === "deployment" &&
+      record.role === "identityRegistry"
+    ) {
+      borrowerIdentityRegistry = record.address;
+    }
   }
 
-  if (!standardFactory || !revolvingFactory || !wrapperFactory || !marketLens) {
+  if (
+    !standardFactory ||
+    !revolvingFactory ||
+    !wrapperFactory ||
+    !marketLens ||
+    !borrowerIdentityRegistry
+  ) {
     throw new Error(
-      "Pending records must resolve standard/revolving hooks factories, wrapper factory, and MarketLens"
+      "Pending records must resolve standard/revolving hooks factories, wrapper factory, borrower identity registry, and MarketLens"
     );
   }
   if (addedRecords !== 3) {
@@ -1959,6 +1972,7 @@ async function runApplyRun(args) {
   deployments.HooksFactoryRevolving = revolvingFactory;
   deployments.MarketLens = marketLens;
   deployments.Wildcat4626WrapperFactory = wrapperFactory;
+  deployments.WildcatBorrowerIdentityRegistry = borrowerIdentityRegistry;
   writeInventory(inventoryPath, inventory);
   writeJsonAtomic(deploymentsPath, deployments);
   console.log(

--- a/src/HooksFactory.sol
+++ b/src/HooksFactory.sol
@@ -11,6 +11,7 @@ import './access/IHooks.sol';
 import './IHooksFactory.sol';
 import './types/TransientBytesArray.sol';
 import './spherex/SphereXProtectedRegisteredBase.sol';
+import './interfaces/IBorrowerIdentityRegistry.sol';
 
 struct TmpMarketParameterStorage {
   address borrower;
@@ -36,6 +37,9 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
 
   TransientBytesArray internal constant _tmpMarketParameters =
     TransientBytesArray.wrap(uint256(keccak256('Transient:TmpMarketParametersStorage')) - 1);
+
+  uint256 internal constant _TMP_BORROWER_PRINCIPAL_SLOT =
+    uint256(keccak256('Transient:TmpBorrowerPrincipal')) - 1;
 
   uint256 internal immutable ownCreate2Prefix = LibStoredInitCode.getCreate2Prefix(address(this));
 
@@ -147,6 +151,20 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     _tmpMarketParameters.write(abi.encode(parameters));
   }
 
+  function _getTmpBorrowerPrincipal() internal view returns (address principal) {
+    uint256 slot = _TMP_BORROWER_PRINCIPAL_SLOT;
+    assembly {
+      principal := tload(slot)
+    }
+  }
+
+  function _setTmpBorrowerPrincipal(address principal) internal {
+    uint256 slot = _TMP_BORROWER_PRINCIPAL_SLOT;
+    assembly {
+      tstore(slot, principal)
+    }
+  }
+
   // ========================================================================== //
   //                                  Modifiers                                 //
   // ========================================================================== //
@@ -156,6 +174,17 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
       revert CallerNotArchControllerOwner();
     }
     _;
+  }
+
+  function _resolveBorrowerPrincipal(
+    address borrower
+  ) internal view returns (address principal) {
+    (bool success, bytes memory returnData) = borrowerIdentityRegistry.staticcall(
+      abi.encodeCall(IBorrowerIdentityRegistry.resolveBorrower, (borrower))
+    );
+    if (!success || returnData.length != 0x20) revert NotApprovedBorrower();
+    principal = abi.decode(returnData, (address));
+    if (principal == address(0)) revert NotApprovedBorrower();
   }
 
   // ========================================================================== //
@@ -322,17 +351,15 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
   // ========================================================================== //
 
   /// @dev Deploy a hooks instance for an approved template with constructor args.
-  ///      Callable by approved borrowers on the arch-controller.
+  ///      Hooks are deployed and indexed under the caller's resolved principal.
   ///      Origination fees are not charged here; they are paid when a market
   ///      is deployed with the instance.
   function deployHooksInstance(
     address hooksTemplate,
     bytes calldata constructorArgs
   ) external override nonReentrant returns (address hooksInstance) {
-    if (!IWildcatArchController(_archController).isRegisteredBorrower(msg.sender)) {
-      revert NotApprovedBorrower();
-    }
-    hooksInstance = _deployHooksInstance(hooksTemplate, constructorArgs);
+    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
+    hooksInstance = _deployHooksInstance(borrowerPrincipal, hooksTemplate, constructorArgs);
   }
 
   function getHooksInstancesForBorrower(
@@ -352,6 +379,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
   }
 
   function _deployHooksInstance(
+    address borrowerPrincipal,
     address hooksTemplate,
     bytes calldata constructorArgs
   ) internal returns (address hooksInstance) {
@@ -363,17 +391,17 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
       revert HooksTemplateNotAvailable();
     }
 
-    uint256 numHooksForBorrower = _hooksInstancesByBorrower[msg.sender].length;
+    uint256 numHooksForBorrower = _hooksInstancesByBorrower[borrowerPrincipal].length;
     bytes32 salt;
     assembly {
-      salt := or(shl(96, caller()), numHooksForBorrower)
+      salt := or(shl(96, borrowerPrincipal), numHooksForBorrower)
       let initCodePointer := mload(0x40)
       let initCodeSize := sub(extcodesize(hooksTemplate), 1)
       // Copy code from target address to memory starting at byte 1
       extcodecopy(hooksTemplate, initCodePointer, 1, initCodeSize)
       let endInitCodePointer := add(initCodePointer, initCodeSize)
-      // Write the address of the caller as the first parameter
-      mstore(endInitCodePointer, caller())
+      // Write the borrower principal as the first parameter
+      mstore(endInitCodePointer, borrowerPrincipal)
       // Write the offset to the encoded constructor args
       mstore(add(endInitCodePointer, 0x20), 0x40)
       // Write the length of the encoded constructor args
@@ -390,7 +418,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
         revert(0x1c, 0x04)
       }
     }
-    _hooksInstancesByBorrower[msg.sender].push(hooksInstance);
+    _hooksInstancesByBorrower[borrowerPrincipal].push(hooksInstance);
 
     emit HooksInstanceDeployed(hooksInstance, hooksTemplate);
     getHooksTemplateForInstance[hooksInstance] = hooksTemplate;
@@ -459,7 +487,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     parameters.archController = _archController;
     parameters.sphereXEngine = sphereXEngine();
     parameters.hooks = tmp.hooks;
-    parameters.borrowerPrincipal = tmp.borrower;
+    parameters.borrowerPrincipal = _getTmpBorrowerPrincipal();
     parameters.borrowerIdentityRegistry = borrowerIdentityRegistry;
   }
 
@@ -493,6 +521,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
   function _deployMarket(
     DeployMarketInputs memory parameters,
     bytes memory hooksData,
+    address borrowerPrincipal,
     address hooksTemplate,
     HooksTemplate memory templateDetails,
     bytes32 salt,
@@ -526,7 +555,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     market = LibStoredInitCode.calculateCreate2Address(ownCreate2Prefix, salt, marketInitCodeHash);
 
     parameters.hooks = IHooks(hooksInstance).onCreateMarket(
-      msg.sender,
+      borrowerPrincipal,
       market,
       parameters,
       hooksData
@@ -560,6 +589,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     }
 
     _setTmpMarketParameters(tmp);
+    _setTmpBorrowerPrincipal(borrowerPrincipal);
 
     if (market.code.length != 0) {
       revert MarketAlreadyExists();
@@ -571,6 +601,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     IWildcatArchController(_archController).registerMarket(market);
 
     _tmpMarketParameters.setEmpty();
+    _setTmpBorrowerPrincipal(address(0));
 
     _marketsByHooksTemplate[hooksTemplate].push(market);
     _marketsByHooksInstance[hooksInstance].push(market);
@@ -591,8 +622,8 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     );
   }
 
-  /// @dev Deploy a market for an approved borrower using an existing hooks instance.
-  ///      Reverts if borrower, hooks instance, fees, asset or deployment checks fail.
+  /// @dev Deploy a market for a recognized borrower identity using an existing hooks instance.
+  ///      Reverts if identity, hooks instance, fees, asset or deployment checks fail.
   function deployMarket(
     DeployMarketInputs calldata parameters,
     bytes calldata hooksData,
@@ -600,9 +631,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     address originationFeeAsset,
     uint256 originationFeeAmount
   ) external override nonReentrant returns (address market) {
-    if (!IWildcatArchController(_archController).isRegisteredBorrower(msg.sender)) {
-      revert NotApprovedBorrower();
-    }
+    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
     address hooksInstance = parameters.hooks.hooksAddress();
     address hooksTemplate = getHooksTemplateForInstance[hooksInstance];
     if (hooksTemplate == address(0)) {
@@ -612,6 +641,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     market = _deployMarket(
       parameters,
       hooksData,
+      borrowerPrincipal,
       hooksTemplate,
       templateDetails,
       salt,
@@ -620,8 +650,8 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     );
   }
 
-  /// @dev Deploy a hooks instance, then deploy a market for an approved borrower.
-  ///      Reverts if borrower, template, fees, asset or deployment checks fail.
+  /// @dev Deploy a principal-administered hooks instance, then deploy a market for the caller.
+  ///      Reverts if identity, template, fees, asset or deployment checks fail.
   function deployMarketAndHooks(
     address hooksTemplate,
     bytes calldata hooksTemplateArgs,
@@ -631,18 +661,21 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     address originationFeeAsset,
     uint256 originationFeeAmount
   ) external override nonReentrant returns (address market, address hooksInstance) {
-    if (!IWildcatArchController(_archController).isRegisteredBorrower(msg.sender)) {
-      revert NotApprovedBorrower();
-    }
+    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
     HooksTemplate memory templateDetails = _templateDetails[hooksTemplate];
     if (!templateDetails.exists) {
       revert HooksTemplateNotFound();
     }
-    hooksInstance = _deployHooksInstance(hooksTemplate, hooksTemplateArgs);
+    hooksInstance = _deployHooksInstance(
+      borrowerPrincipal,
+      hooksTemplate,
+      hooksTemplateArgs
+    );
     parameters.hooks = parameters.hooks.setHooksAddress(hooksInstance);
     market = _deployMarket(
       parameters,
       hooksData,
+      borrowerPrincipal,
       hooksTemplate,
       templateDetails,
       salt,

--- a/src/HooksFactory.sol
+++ b/src/HooksFactory.sol
@@ -47,6 +47,8 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
 
   address public immutable override wrapperFactory;
 
+  address public immutable override borrowerIdentityRegistry;
+
   /**
    * @dev Return the contract name "WildcatHooksFactory"
    */
@@ -96,13 +98,15 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     address _sanctionsSentinel,
     address _wrapperFactory,
     address _marketInitCodeStorage,
-    uint256 _marketInitCodeHash
+    uint256 _marketInitCodeHash,
+    address _borrowerIdentityRegistry
   ) {
     marketInitCodeStorage = _marketInitCodeStorage;
     marketInitCodeHash = _marketInitCodeHash;
     _archController = archController_;
     sanctionsSentinel = _sanctionsSentinel;
     wrapperFactory = _wrapperFactory;
+    borrowerIdentityRegistry = _borrowerIdentityRegistry;
     __SphereXProtectedRegisteredBase_init(IWildcatArchController(archController_).sphereXEngine());
   }
 
@@ -456,6 +460,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     parameters.sphereXEngine = sphereXEngine();
     parameters.hooks = tmp.hooks;
     parameters.borrowerPrincipal = tmp.borrower;
+    parameters.borrowerIdentityRegistry = borrowerIdentityRegistry;
   }
 
   /// @dev Returns the CREATE2 market address for `salt` and this factory's init code.

--- a/src/HooksFactory.sol
+++ b/src/HooksFactory.sol
@@ -455,6 +455,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     parameters.archController = _archController;
     parameters.sphereXEngine = sphereXEngine();
     parameters.hooks = tmp.hooks;
+    parameters.borrowerPrincipal = tmp.borrower;
   }
 
   /// @dev Returns the CREATE2 market address for `salt` and this factory's init code.

--- a/src/HooksFactoryRevolving.sol
+++ b/src/HooksFactoryRevolving.sol
@@ -11,6 +11,7 @@ import './access/IHooks.sol';
 import './IHooksFactoryRevolving.sol';
 import './types/TransientBytesArray.sol';
 import './spherex/SphereXProtectedRegisteredBase.sol';
+import './interfaces/IBorrowerIdentityRegistry.sol';
 
 struct TmpRevolvingMarketParameterStorage {
   address borrower;
@@ -37,6 +38,7 @@ struct TmpRevolvingMarketParameterStorage {
  */
 struct DeployRevolvingMarketRuntimeParameters {
   address hooksTemplate;
+  address borrowerPrincipal;
   bytes32 salt;
   address originationFeeAsset;
   uint256 originationFeeAmount;
@@ -54,6 +56,9 @@ contract HooksFactoryRevolving is
     TransientBytesArray.wrap(
       uint256(keccak256('Transient:TmpRevolvingMarketParameterStorage')) - 1
     );
+
+  uint256 internal constant _TMP_BORROWER_PRINCIPAL_SLOT =
+    uint256(keccak256('Transient:TmpBorrowerPrincipal')) - 1;
 
   TransientBytesArray internal constant _tmpRevolvingMarketData =
     TransientBytesArray.wrap(uint256(keccak256('Transient:TmpRevolvingMarketData')) - 1);
@@ -164,6 +169,20 @@ contract HooksFactoryRevolving is
     _tmpMarketParameters.write(abi.encode(parameters));
   }
 
+  function _getTmpBorrowerPrincipal() internal view returns (address principal) {
+    uint256 slot = _TMP_BORROWER_PRINCIPAL_SLOT;
+    assembly {
+      principal := tload(slot)
+    }
+  }
+
+  function _setTmpBorrowerPrincipal(address principal) internal {
+    uint256 slot = _TMP_BORROWER_PRINCIPAL_SLOT;
+    assembly {
+      tstore(slot, principal)
+    }
+  }
+
   /**
    * @dev Set the temporary commitment fee in transient storage.
    */
@@ -187,6 +206,17 @@ contract HooksFactoryRevolving is
       revert CallerNotArchControllerOwner();
     }
     _;
+  }
+
+  function _resolveBorrowerPrincipal(
+    address borrower
+  ) internal view returns (address principal) {
+    (bool success, bytes memory returnData) = borrowerIdentityRegistry.staticcall(
+      abi.encodeCall(IBorrowerIdentityRegistry.resolveBorrower, (borrower))
+    );
+    if (!success || returnData.length != 0x20) revert NotApprovedBorrower();
+    principal = abi.decode(returnData, (address));
+    if (principal == address(0)) revert NotApprovedBorrower();
   }
 
   // ========================================================================== //
@@ -349,17 +379,15 @@ contract HooksFactoryRevolving is
   // ========================================================================== //
 
   /// @dev Deploy a hooks instance for an approved template with constructor args.
-  ///      Callable by approved borrowers on the arch-controller.
+  ///      Hooks are deployed and indexed under the caller's resolved principal.
   ///      Origination fees are not charged here; they are paid when a market
   ///      is deployed with the instance.
   function deployHooksInstance(
     address hooksTemplate,
     bytes calldata constructorArgs
   ) external override nonReentrant returns (address hooksInstance) {
-    if (!IWildcatArchController(_archController).isRegisteredBorrower(msg.sender)) {
-      revert NotApprovedBorrower();
-    }
-    hooksInstance = _deployHooksInstance(hooksTemplate, constructorArgs);
+    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
+    hooksInstance = _deployHooksInstance(borrowerPrincipal, hooksTemplate, constructorArgs);
   }
 
   function getHooksInstancesForBorrower(
@@ -379,6 +407,7 @@ contract HooksFactoryRevolving is
   }
 
   function _deployHooksInstance(
+    address borrowerPrincipal,
     address hooksTemplate,
     bytes calldata constructorArgs
   ) internal returns (address hooksInstance) {
@@ -390,17 +419,17 @@ contract HooksFactoryRevolving is
       revert HooksTemplateNotAvailable();
     }
 
-    uint256 numHooksForBorrower = _hooksInstancesByBorrower[msg.sender].length;
+    uint256 numHooksForBorrower = _hooksInstancesByBorrower[borrowerPrincipal].length;
     bytes32 salt;
     assembly {
-      salt := or(shl(96, caller()), numHooksForBorrower)
+      salt := or(shl(96, borrowerPrincipal), numHooksForBorrower)
       let initCodePointer := mload(0x40)
       let initCodeSize := sub(extcodesize(hooksTemplate), 1)
       // Copy code from target address to memory starting at byte 1
       extcodecopy(hooksTemplate, initCodePointer, 1, initCodeSize)
       let endInitCodePointer := add(initCodePointer, initCodeSize)
-      // Write the address of the caller as the first parameter
-      mstore(endInitCodePointer, caller())
+      // Write the borrower principal as the first parameter
+      mstore(endInitCodePointer, borrowerPrincipal)
       // Write the offset to the encoded constructor args
       mstore(add(endInitCodePointer, 0x20), 0x40)
       // Write the length of the encoded constructor args
@@ -417,7 +446,7 @@ contract HooksFactoryRevolving is
         revert(0x1c, 0x04)
       }
     }
-    _hooksInstancesByBorrower[msg.sender].push(hooksInstance);
+    _hooksInstancesByBorrower[borrowerPrincipal].push(hooksInstance);
 
     emit HooksInstanceDeployed(hooksInstance, hooksTemplate);
     getHooksTemplateForInstance[hooksInstance] = hooksTemplate;
@@ -486,7 +515,7 @@ contract HooksFactoryRevolving is
     parameters.archController = _archController;
     parameters.sphereXEngine = sphereXEngine();
     parameters.hooks = tmp.hooks;
-    parameters.borrowerPrincipal = tmp.borrower;
+    parameters.borrowerPrincipal = _getTmpBorrowerPrincipal();
     parameters.borrowerIdentityRegistry = borrowerIdentityRegistry;
   }
 
@@ -581,7 +610,7 @@ contract HooksFactoryRevolving is
     );
 
     parameters.hooks = IHooks(hooksInstance).onCreateMarket(
-      msg.sender,
+      runtimeParams.borrowerPrincipal,
       market,
       parameters,
       hooksData
@@ -615,6 +644,7 @@ contract HooksFactoryRevolving is
     }
 
     _setTmpMarketParameters(tmp);
+    _setTmpBorrowerPrincipal(runtimeParams.borrowerPrincipal);
     _setTmpCommitmentFeeBips(runtimeParams.commitmentFeeBips);
 
     if (market.code.length != 0) {
@@ -630,6 +660,7 @@ contract HooksFactoryRevolving is
     IWildcatArchController(_archController).registerMarket(market);
 
     _tmpMarketParameters.setEmpty();
+    _setTmpBorrowerPrincipal(address(0));
     _tmpRevolvingMarketData.setEmpty();
 
     _marketsByHooksTemplate[runtimeParams.hooksTemplate].push(market);
@@ -668,9 +699,7 @@ contract HooksFactoryRevolving is
     address originationFeeAsset,
     uint256 originationFeeAmount
   ) external override nonReentrant returns (address market) {
-    if (!IWildcatArchController(_archController).isRegisteredBorrower(msg.sender)) {
-      revert NotApprovedBorrower();
-    }
+    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
     uint16 commitmentFeeBips = _decodeMarketData(marketData);
     address hooksTemplate = getHooksTemplateForInstance[parameters.hooks.hooksAddress()];
     if (hooksTemplate == address(0)) {
@@ -679,6 +708,7 @@ contract HooksFactoryRevolving is
     DeployRevolvingMarketRuntimeParameters
       memory runtimeParams = DeployRevolvingMarketRuntimeParameters({
         hooksTemplate: hooksTemplate,
+        borrowerPrincipal: borrowerPrincipal,
         salt: salt,
         originationFeeAsset: originationFeeAsset,
         originationFeeAmount: originationFeeAmount,
@@ -697,19 +727,22 @@ contract HooksFactoryRevolving is
     address originationFeeAsset,
     uint256 originationFeeAmount
   ) external override nonReentrant returns (address market, address hooksInstance) {
-    if (!IWildcatArchController(_archController).isRegisteredBorrower(msg.sender)) {
-      revert NotApprovedBorrower();
-    }
+    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
     DeployRevolvingMarketRuntimeParameters
       memory runtimeParams = DeployRevolvingMarketRuntimeParameters({
         hooksTemplate: hooksTemplate,
+        borrowerPrincipal: borrowerPrincipal,
         salt: salt,
         originationFeeAsset: originationFeeAsset,
         originationFeeAmount: originationFeeAmount,
         commitmentFeeBips: _decodeMarketData(marketData)
       });
     // `_deployHooksInstance` reverts if the template does not exist or is disabled.
-    hooksInstance = _deployHooksInstance(hooksTemplate, hooksConstructorArgs);
+    hooksInstance = _deployHooksInstance(
+      borrowerPrincipal,
+      hooksTemplate,
+      hooksConstructorArgs
+    );
     DeployMarketInputs memory marketInputs = parameters;
     marketInputs.hooks = marketInputs.hooks.setHooksAddress(hooksInstance);
     market = _deployMarket(marketInputs, hooksData, runtimeParams);

--- a/src/HooksFactoryRevolving.sol
+++ b/src/HooksFactoryRevolving.sol
@@ -482,6 +482,7 @@ contract HooksFactoryRevolving is
     parameters.archController = _archController;
     parameters.sphereXEngine = sphereXEngine();
     parameters.hooks = tmp.hooks;
+    parameters.borrowerPrincipal = tmp.borrower;
   }
 
   function computeMarketAddress(bytes32 salt) external view override returns (address) {

--- a/src/HooksFactoryRevolving.sol
+++ b/src/HooksFactoryRevolving.sol
@@ -75,6 +75,8 @@ contract HooksFactoryRevolving is
 
   address public immutable override wrapperFactory;
 
+  address public immutable override borrowerIdentityRegistry;
+
   /**
    * @dev Return the contract name "WildcatHooksFactoryRevolving"
    */
@@ -113,13 +115,15 @@ contract HooksFactoryRevolving is
     address _sanctionsSentinel,
     address _wrapperFactory,
     address _marketInitCodeStorage,
-    uint256 _marketInitCodeHash
+    uint256 _marketInitCodeHash,
+    address _borrowerIdentityRegistry
   ) {
     marketInitCodeStorage = _marketInitCodeStorage;
     marketInitCodeHash = _marketInitCodeHash;
     _archController = archController_;
     sanctionsSentinel = _sanctionsSentinel;
     wrapperFactory = _wrapperFactory;
+    borrowerIdentityRegistry = _borrowerIdentityRegistry;
     __SphereXProtectedRegisteredBase_init(IWildcatArchController(archController_).sphereXEngine());
   }
 
@@ -483,6 +487,7 @@ contract HooksFactoryRevolving is
     parameters.sphereXEngine = sphereXEngine();
     parameters.hooks = tmp.hooks;
     parameters.borrowerPrincipal = tmp.borrower;
+    parameters.borrowerIdentityRegistry = borrowerIdentityRegistry;
   }
 
   function computeMarketAddress(bytes32 salt) external view override returns (address) {

--- a/src/IHooksFactory.sol
+++ b/src/IHooksFactory.sol
@@ -85,6 +85,8 @@ interface IHooksFactory is IHooksFactoryEventsAndErrors {
 
   function wrapperFactory() external view returns (address);
 
+  function borrowerIdentityRegistry() external view returns (address);
+
   function marketInitCodeStorage() external view returns (address);
 
   function marketInitCodeHash() external view returns (uint256);

--- a/src/IHooksFactory.sol
+++ b/src/IHooksFactory.sol
@@ -192,7 +192,7 @@ interface IHooksFactory is IHooksFactoryEventsAndErrors {
   ///      - Maps the hooks instance to the template address.
   ///
   ///      Reverts if:
-  ///      - The caller is not an approved borrower.
+  ///      - The caller does not resolve to a registered principal.
   ///      - The template does not exist.
   ///      - The template is not enabled.
   ///      - The deployment fails.
@@ -201,6 +201,7 @@ interface IHooksFactory is IHooksFactoryEventsAndErrors {
     bytes calldata constructorArgs
   ) external returns (address hooksDeployment);
 
+  /// @dev Hooks deployed under a direct principal or registered account are indexed by principal.
   function getHooksInstancesForBorrower(address borrower) external view returns (address[] memory);
 
   function getHooksInstancesCountForBorrower(address borrower) external view returns (uint256);
@@ -231,6 +232,8 @@ interface IHooksFactory is IHooksFactoryEventsAndErrors {
   function getMarketParameters() external view returns (MarketParameters memory parameters);
 
   /// @dev Deploy a market with an existing hooks deployment (in `parameters.hooks`)
+  ///      The caller becomes the market borrower. Its resolved principal is supplied
+  ///      to the hook and stored on the market.
   ///
   ///      On success:
   ///      - Pays the origination fee (if applicable).
@@ -239,7 +242,7 @@ interface IHooksFactory is IHooksFactoryEventsAndErrors {
   ///      - Emits `MarketDeployed`.
   ///
   ///      Reverts if:
-  ///      - The caller is not an approved borrower.
+  ///      - The caller does not resolve to a registered principal.
   ///      - The hooks instance does not exist.
   ///      - Payment of origination fee fails.
   ///      - The deployment fails.
@@ -254,9 +257,9 @@ interface IHooksFactory is IHooksFactoryEventsAndErrors {
     uint256 originationFeeAmount
   ) external returns (address market);
 
-  /// @dev Deploy a hooks instance for an approved template,then deploy a new market with that
-  ///      instance as its hooks contract.
-  ///      Will call `onCreateMarket` on `parameters.hooks`.
+  /// @dev Deploy a principal-administered hooks instance, then deploy a new market owned by
+  ///      the calling principal or registered account.
+  ///      Will call `onCreateMarket` on the new hooks instance.
   function deployMarketAndHooks(
     address hooksTemplate,
     bytes calldata hooksConstructorArgs,

--- a/src/IHooksFactoryRevolving.sol
+++ b/src/IHooksFactoryRevolving.sol
@@ -15,6 +15,8 @@ interface IHooksFactoryRevolving is IHooksFactoryEventsAndErrors {
 
   function wrapperFactory() external view returns (address);
 
+  function borrowerIdentityRegistry() external view returns (address);
+
   function marketInitCodeStorage() external view returns (address);
 
   function marketInitCodeHash() external view returns (uint256);

--- a/src/IHooksFactoryRevolving.sol
+++ b/src/IHooksFactoryRevolving.sol
@@ -122,7 +122,7 @@ interface IHooksFactoryRevolving is IHooksFactoryEventsAndErrors {
   ///      - Maps the hooks instance to the template address.
   ///
   ///      Reverts if:
-  ///      - The caller is not an approved borrower.
+  ///      - The caller does not resolve to a registered principal.
   ///      - The template does not exist.
   ///      - The template is not enabled.
   ///      - The deployment fails.
@@ -131,6 +131,7 @@ interface IHooksFactoryRevolving is IHooksFactoryEventsAndErrors {
     bytes calldata constructorArgs
   ) external returns (address hooksDeployment);
 
+  /// @dev Hooks deployed under a direct principal or registered account are indexed by principal.
   function getHooksInstancesForBorrower(address borrower) external view returns (address[] memory);
 
   function getHooksInstancesCountForBorrower(address borrower) external view returns (uint256);
@@ -166,6 +167,8 @@ interface IHooksFactoryRevolving is IHooksFactoryEventsAndErrors {
   function getRevolvingMarketCommitmentFeeBips() external view returns (uint16);
 
   /// @dev Deploy a revolving market with an existing hooks deployment (in `parameters.hooks`)
+  ///      The caller becomes the market borrower. Its resolved principal is supplied
+  ///      to the hook and stored on the market.
   ///
   ///      `hooksData` is hook-owned data forwarded unchanged to hooks callbacks.
   ///      `marketData` is factory-owned data decoded by this factory.
@@ -178,7 +181,7 @@ interface IHooksFactoryRevolving is IHooksFactoryEventsAndErrors {
   ///      - Emits `MarketDeployed`.
   ///
   ///      Reverts if:
-  ///      - The caller is not an approved borrower.
+  ///      - The caller does not resolve to a registered principal.
   ///      - The hooks instance does not exist.
   ///      - `marketData` is malformed or specifies an invalid commitment fee.
   ///      - Payment of origination fee fails.
@@ -195,8 +198,8 @@ interface IHooksFactoryRevolving is IHooksFactoryEventsAndErrors {
     uint256 originationFeeAmount
   ) external returns (address market);
 
-  /// @dev Deploy a hooks instance for an approved template, then deploy a new
-  ///      revolving market with that instance as its hooks contract.
+  /// @dev Deploy a principal-administered hooks instance, then deploy a new
+  ///      revolving market owned by the calling principal or registered account.
   ///      Will call `onCreateMarket` on the newly deployed hooks instance,
   ///      which replaces the hooks address in `parameters.hooks`.
   ///      `marketData` uses the same encoding as `deployMarket`.

--- a/src/WildcatBorrowerIdentityRegistry.sol
+++ b/src/WildcatBorrowerIdentityRegistry.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
+pragma solidity >=0.8.20;
+
+import { EnumerableSet } from 'openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+import './interfaces/IBorrowerIdentityRegistry.sol';
+import './interfaces/IWildcatArchController.sol';
+
+/**
+ * @dev Resolves borrower accounts to registered principals. The current ArchController
+ *      owner may approve factories, but no association can be changed or removed.
+ */
+contract WildcatBorrowerIdentityRegistry is IBorrowerIdentityRegistry {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  address internal immutable _archController;
+
+  EnumerableSet.AddressSet internal _accountFactories;
+
+  mapping(address account => address principal) public override principalOf;
+  mapping(address account => address accountFactory) public override accountFactoryOf;
+  mapping(address principal => address[] accounts) internal _borrowerAccounts;
+  mapping(address accountFactory => address[] accounts) internal _borrowerAccountsForFactory;
+
+  constructor(address archController_) {
+    if (archController_ == address(0) || archController_.code.length == 0) {
+      revert InvalidArchController();
+    }
+    _archController = archController_;
+  }
+
+  function archController() external view override returns (address) {
+    return _archController;
+  }
+
+  modifier onlyArchControllerOwner() {
+    if (msg.sender != IWildcatArchController(_archController).owner()) {
+      revert CallerNotArchControllerOwner();
+    }
+    _;
+  }
+
+  modifier onlyAccountFactory() {
+    if (!_accountFactories.contains(msg.sender)) {
+      revert CallerNotAccountFactory();
+    }
+    _;
+  }
+
+  function addAccountFactory(
+    address accountFactory
+  ) external override onlyArchControllerOwner {
+    if (accountFactory == address(0) || accountFactory.code.length == 0) {
+      revert InvalidAccountFactory();
+    }
+    if (!_accountFactories.add(accountFactory)) {
+      revert AccountFactoryAlreadyExists();
+    }
+    emit AccountFactoryAdded(accountFactory);
+  }
+
+  function removeAccountFactory(
+    address accountFactory
+  ) external override onlyArchControllerOwner {
+    if (!_accountFactories.remove(accountFactory)) {
+      revert AccountFactoryDoesNotExist();
+    }
+    emit AccountFactoryRemoved(accountFactory);
+  }
+
+  function isAccountFactory(address accountFactory) external view override returns (bool) {
+    return _accountFactories.contains(accountFactory);
+  }
+
+  function getAccountFactories() external view override returns (address[] memory) {
+    return _accountFactories.values();
+  }
+
+  function getAccountFactories(
+    uint256 start,
+    uint256 end
+  ) external view override returns (address[] memory arr) {
+    if (start > end) revert InvalidPaginationRange();
+    uint256 length = _accountFactories.length();
+    if (end > length) end = length;
+    if (start >= end) return new address[](0);
+    uint256 count = end - start;
+    arr = new address[](count);
+    for (uint256 i = 0; i < count; i++) {
+      arr[i] = _accountFactories.at(start + i);
+    }
+  }
+
+  function getAccountFactoriesCount() external view override returns (uint256) {
+    return _accountFactories.length();
+  }
+
+  function registerBorrowerAccount(
+    address account,
+    address principal
+  ) external override onlyAccountFactory {
+    if (principal == address(0)) revert BorrowerPrincipalNotRegistered();
+    if (account == address(0) || account == principal || account.code.length == 0) {
+      revert InvalidBorrowerAccount();
+    }
+    if (principalOf[account] != address(0)) {
+      revert BorrowerAccountAlreadyRegistered();
+    }
+
+    IWildcatArchController controller = IWildcatArchController(_archController);
+    if (controller.isRegisteredBorrower(account) || principalOf[principal] != address(0)) {
+      revert AmbiguousBorrowerIdentity();
+    }
+    if (!controller.isRegisteredBorrower(principal)) {
+      revert BorrowerPrincipalNotRegistered();
+    }
+
+    principalOf[account] = principal;
+    accountFactoryOf[account] = msg.sender;
+    _borrowerAccounts[principal].push(account);
+    _borrowerAccountsForFactory[msg.sender].push(account);
+
+    emit BorrowerAccountRegistered(account, principal, msg.sender);
+  }
+
+  function resolveBorrower(address borrower) external view override returns (address principal) {
+    if (borrower == address(0)) revert BorrowerIdentityNotFound();
+
+    principal = principalOf[borrower];
+    IWildcatArchController controller = IWildcatArchController(_archController);
+    if (controller.isRegisteredBorrower(borrower)) {
+      if (principal != address(0)) revert AmbiguousBorrowerIdentity();
+      return borrower;
+    }
+    if (principal == address(0)) revert BorrowerIdentityNotFound();
+    if (principalOf[principal] != address(0)) revert AmbiguousBorrowerIdentity();
+    if (!controller.isRegisteredBorrower(principal)) {
+      revert BorrowerPrincipalNotRegistered();
+    }
+  }
+
+  function getBorrowerAccounts(
+    address principal
+  ) external view override returns (address[] memory) {
+    return _borrowerAccounts[principal];
+  }
+
+  function getBorrowerAccounts(
+    address principal,
+    uint256 start,
+    uint256 end
+  ) external view override returns (address[] memory) {
+    return _getAddressSlice(_borrowerAccounts[principal], start, end);
+  }
+
+  function getBorrowerAccountsCount(address principal) external view override returns (uint256) {
+    return _borrowerAccounts[principal].length;
+  }
+
+  function getBorrowerAccountsForFactory(
+    address accountFactory
+  ) external view override returns (address[] memory) {
+    return _borrowerAccountsForFactory[accountFactory];
+  }
+
+  function getBorrowerAccountsForFactory(
+    address accountFactory,
+    uint256 start,
+    uint256 end
+  ) external view override returns (address[] memory) {
+    return _getAddressSlice(_borrowerAccountsForFactory[accountFactory], start, end);
+  }
+
+  function getBorrowerAccountsForFactoryCount(
+    address accountFactory
+  ) external view override returns (uint256) {
+    return _borrowerAccountsForFactory[accountFactory].length;
+  }
+
+  function _getAddressSlice(
+    address[] storage values,
+    uint256 start,
+    uint256 end
+  ) internal view returns (address[] memory arr) {
+    if (start > end) revert InvalidPaginationRange();
+    uint256 length = values.length;
+    if (end > length) end = length;
+    if (start >= end) return new address[](0);
+    uint256 count = end - start;
+    arr = new address[](count);
+    for (uint256 i = 0; i < count; i++) {
+      arr[i] = values[start + i];
+    }
+  }
+}

--- a/src/WildcatBorrowerIdentityRegistry.sol
+++ b/src/WildcatBorrowerIdentityRegistry.sol
@@ -7,7 +7,7 @@ import './interfaces/IWildcatArchController.sol';
 
 /**
  * @dev Resolves borrower accounts to registered principals. The current ArchController
- *      owner may approve factories, but no association can be changed or removed.
+ *      owner may approve factories, but account principals manage their own transfers.
  */
 contract WildcatBorrowerIdentityRegistry is IBorrowerIdentityRegistry {
   using EnumerableSet for EnumerableSet.AddressSet;
@@ -17,8 +17,9 @@ contract WildcatBorrowerIdentityRegistry is IBorrowerIdentityRegistry {
   EnumerableSet.AddressSet internal _accountFactories;
 
   mapping(address account => address principal) public override principalOf;
+  mapping(address account => address pendingPrincipal) public override pendingPrincipalOf;
   mapping(address account => address accountFactory) public override accountFactoryOf;
-  mapping(address principal => address[] accounts) internal _borrowerAccounts;
+  mapping(address principal => EnumerableSet.AddressSet accounts) internal _borrowerAccounts;
   mapping(address accountFactory => address[] accounts) internal _borrowerAccountsForFactory;
 
   constructor(address archController_) {
@@ -116,10 +117,59 @@ contract WildcatBorrowerIdentityRegistry is IBorrowerIdentityRegistry {
 
     principalOf[account] = principal;
     accountFactoryOf[account] = msg.sender;
-    _borrowerAccounts[principal].push(account);
+    _borrowerAccounts[principal].add(account);
     _borrowerAccountsForFactory[msg.sender].push(account);
 
     emit BorrowerAccountRegistered(account, principal, msg.sender);
+  }
+
+  function requestBorrowerAccountPrincipalTransfer(
+    address account,
+    address newPrincipal
+  ) external override {
+    address currentPrincipal = _getAccountPrincipal(account);
+    if (msg.sender != currentPrincipal) revert CallerNotBorrowerAccountPrincipal();
+    _validatePrincipalTransferTarget(account, currentPrincipal, newPrincipal);
+
+    address previousPendingPrincipal = pendingPrincipalOf[account];
+    pendingPrincipalOf[account] = newPrincipal;
+    emit BorrowerAccountPrincipalTransferRequested(
+      account,
+      currentPrincipal,
+      previousPendingPrincipal,
+      newPrincipal
+    );
+  }
+
+  function cancelBorrowerAccountPrincipalTransfer(address account) external override {
+    address currentPrincipal = _getAccountPrincipal(account);
+    if (msg.sender != currentPrincipal) revert CallerNotBorrowerAccountPrincipal();
+
+    address cancelledPendingPrincipal = pendingPrincipalOf[account];
+    if (cancelledPendingPrincipal == address(0)) {
+      revert NoPendingBorrowerAccountPrincipalTransfer();
+    }
+    delete pendingPrincipalOf[account];
+    emit BorrowerAccountPrincipalTransferCancelled(
+      account,
+      currentPrincipal,
+      cancelledPendingPrincipal
+    );
+  }
+
+  function acceptBorrowerAccountPrincipalTransfer(address account) external override {
+    address newPrincipal = pendingPrincipalOf[account];
+    if (msg.sender != newPrincipal) revert CallerNotPendingBorrowerAccountPrincipal();
+
+    address previousPrincipal = _getAccountPrincipal(account);
+    _validatePrincipalTransferTarget(account, previousPrincipal, newPrincipal);
+
+    delete pendingPrincipalOf[account];
+    _borrowerAccounts[previousPrincipal].remove(account);
+    _borrowerAccounts[newPrincipal].add(account);
+    principalOf[account] = newPrincipal;
+
+    emit BorrowerAccountPrincipalTransferred(account, previousPrincipal, newPrincipal);
   }
 
   function resolveBorrower(address borrower) external view override returns (address principal) {
@@ -141,7 +191,7 @@ contract WildcatBorrowerIdentityRegistry is IBorrowerIdentityRegistry {
   function getBorrowerAccounts(
     address principal
   ) external view override returns (address[] memory) {
-    return _borrowerAccounts[principal];
+    return _borrowerAccounts[principal].values();
   }
 
   function getBorrowerAccounts(
@@ -149,11 +199,11 @@ contract WildcatBorrowerIdentityRegistry is IBorrowerIdentityRegistry {
     uint256 start,
     uint256 end
   ) external view override returns (address[] memory) {
-    return _getAddressSlice(_borrowerAccounts[principal], start, end);
+    return _getAddressSetSlice(_borrowerAccounts[principal], start, end);
   }
 
   function getBorrowerAccountsCount(address principal) external view override returns (uint256) {
-    return _borrowerAccounts[principal].length;
+    return _borrowerAccounts[principal].length();
   }
 
   function getBorrowerAccountsForFactory(
@@ -189,6 +239,49 @@ contract WildcatBorrowerIdentityRegistry is IBorrowerIdentityRegistry {
     arr = new address[](count);
     for (uint256 i = 0; i < count; i++) {
       arr[i] = values[start + i];
+    }
+  }
+
+  function _getAccountPrincipal(address account) internal view returns (address principal) {
+    principal = principalOf[account];
+    if (principal == address(0)) revert BorrowerAccountNotRegistered();
+  }
+
+  function _validatePrincipalTransferTarget(
+    address account,
+    address currentPrincipal,
+    address newPrincipal
+  ) internal view {
+    if (
+      newPrincipal == address(0) ||
+      newPrincipal == account ||
+      newPrincipal == currentPrincipal
+    ) {
+      revert InvalidBorrowerAccountPrincipalTransferTarget();
+    }
+
+    IWildcatArchController controller = IWildcatArchController(_archController);
+    if (controller.isRegisteredBorrower(account) || principalOf[newPrincipal] != address(0)) {
+      revert AmbiguousBorrowerIdentity();
+    }
+    if (!controller.isRegisteredBorrower(newPrincipal)) {
+      revert BorrowerPrincipalNotRegistered();
+    }
+  }
+
+  function _getAddressSetSlice(
+    EnumerableSet.AddressSet storage values,
+    uint256 start,
+    uint256 end
+  ) internal view returns (address[] memory arr) {
+    if (start > end) revert InvalidPaginationRange();
+    uint256 length = values.length();
+    if (end > length) end = length;
+    if (start >= end) return new address[](0);
+    uint256 count = end - start;
+    arr = new address[](count);
+    for (uint256 i = 0; i < count; i++) {
+      arr[i] = values.at(start + i);
     }
   }
 }

--- a/src/interfaces/IBorrowerIdentityRegistry.sol
+++ b/src/interfaces/IBorrowerIdentityRegistry.sol
@@ -10,9 +10,14 @@ interface IBorrowerIdentityRegistry {
   error AccountFactoryDoesNotExist();
   error InvalidBorrowerAccount();
   error BorrowerAccountAlreadyRegistered();
+  error BorrowerAccountNotRegistered();
   error BorrowerPrincipalNotRegistered();
   error BorrowerIdentityNotFound();
   error AmbiguousBorrowerIdentity();
+  error CallerNotBorrowerAccountPrincipal();
+  error CallerNotPendingBorrowerAccountPrincipal();
+  error InvalidBorrowerAccountPrincipalTransferTarget();
+  error NoPendingBorrowerAccountPrincipalTransfer();
   error InvalidPaginationRange();
 
   event AccountFactoryAdded(address indexed accountFactory);
@@ -22,11 +27,30 @@ interface IBorrowerIdentityRegistry {
     address indexed principal,
     address indexed accountFactory
   );
+  event BorrowerAccountPrincipalTransferRequested(
+    address indexed account,
+    address indexed currentPrincipal,
+    address previousPendingPrincipal,
+    address indexed pendingPrincipal
+  );
+  event BorrowerAccountPrincipalTransferCancelled(
+    address indexed account,
+    address indexed currentPrincipal,
+    address indexed cancelledPendingPrincipal
+  );
+  event BorrowerAccountPrincipalTransferred(
+    address indexed account,
+    address indexed previousPrincipal,
+    address indexed newPrincipal
+  );
 
   function archController() external view returns (address);
 
-  /// @notice Permanent principal associated with `account`, or zero if it is unknown.
+  /// @notice Current principal associated with `account`, or zero if it is unknown.
   function principalOf(address account) external view returns (address);
+
+  /// @notice Principal that can accept a pending transfer for `account`.
+  function pendingPrincipalOf(address account) external view returns (address);
 
   /// @notice Factory that registered `account`, or zero if it is unknown.
   function accountFactoryOf(address account) external view returns (address);
@@ -49,8 +73,14 @@ interface IBorrowerIdentityRegistry {
 
   function getAccountFactoriesCount() external view returns (uint256);
 
-  /// @notice Permanently associates a deployed borrower account with a registered principal.
+  /// @notice Associates a deployed borrower account with its initial registered principal.
   function registerBorrowerAccount(address account, address principal) external;
+
+  function requestBorrowerAccountPrincipalTransfer(address account, address newPrincipal) external;
+
+  function cancelBorrowerAccountPrincipalTransfer(address account) external;
+
+  function acceptBorrowerAccountPrincipalTransfer(address account) external;
 
   function getBorrowerAccounts(address principal) external view returns (address[] memory);
 

--- a/src/interfaces/IBorrowerIdentityRegistry.sol
+++ b/src/interfaces/IBorrowerIdentityRegistry.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IBorrowerIdentityRegistry {
+  error CallerNotArchControllerOwner();
+  error CallerNotAccountFactory();
+  error InvalidArchController();
+  error InvalidAccountFactory();
+  error AccountFactoryAlreadyExists();
+  error AccountFactoryDoesNotExist();
+  error InvalidBorrowerAccount();
+  error BorrowerAccountAlreadyRegistered();
+  error BorrowerPrincipalNotRegistered();
+  error BorrowerIdentityNotFound();
+  error AmbiguousBorrowerIdentity();
+  error InvalidPaginationRange();
+
+  event AccountFactoryAdded(address indexed accountFactory);
+  event AccountFactoryRemoved(address indexed accountFactory);
+  event BorrowerAccountRegistered(
+    address indexed account,
+    address indexed principal,
+    address indexed accountFactory
+  );
+
+  function archController() external view returns (address);
+
+  /// @notice Permanent principal associated with `account`, or zero if it is unknown.
+  function principalOf(address account) external view returns (address);
+
+  /// @notice Factory that registered `account`, or zero if it is unknown.
+  function accountFactoryOf(address account) external view returns (address);
+
+  /// @notice Resolves a direct principal or borrower account using current ArchController state.
+  function resolveBorrower(address borrower) external view returns (address principal);
+
+  function addAccountFactory(address accountFactory) external;
+
+  function removeAccountFactory(address accountFactory) external;
+
+  function isAccountFactory(address accountFactory) external view returns (bool);
+
+  function getAccountFactories() external view returns (address[] memory);
+
+  function getAccountFactories(
+    uint256 start,
+    uint256 end
+  ) external view returns (address[] memory);
+
+  function getAccountFactoriesCount() external view returns (uint256);
+
+  /// @notice Permanently associates a deployed borrower account with a registered principal.
+  function registerBorrowerAccount(address account, address principal) external;
+
+  function getBorrowerAccounts(address principal) external view returns (address[] memory);
+
+  function getBorrowerAccounts(
+    address principal,
+    uint256 start,
+    uint256 end
+  ) external view returns (address[] memory);
+
+  function getBorrowerAccountsCount(address principal) external view returns (uint256);
+
+  function getBorrowerAccountsForFactory(
+    address accountFactory
+  ) external view returns (address[] memory);
+
+  function getBorrowerAccountsForFactory(
+    address accountFactory,
+    uint256 start,
+    uint256 end
+  ) external view returns (address[] memory);
+
+  function getBorrowerAccountsForFactoryCount(
+    address accountFactory
+  ) external view returns (uint256);
+}

--- a/src/interfaces/IMarketEventsAndErrors.sol
+++ b/src/interfaces/IMarketEventsAndErrors.sol
@@ -82,6 +82,8 @@ interface IMarketEventsAndErrors {
 
   error ProtocolFeeTooHigh();
 
+  error InvalidBorrower();
+
   error InvalidBorrowerIdentityRegistry();
 
   error InvalidBorrowerTransferTarget();

--- a/src/interfaces/IMarketEventsAndErrors.sol
+++ b/src/interfaces/IMarketEventsAndErrors.sol
@@ -82,6 +82,22 @@ interface IMarketEventsAndErrors {
 
   error ProtocolFeeTooHigh();
 
+  error InvalidBorrowerIdentityRegistry();
+
+  error InvalidBorrowerTransferTarget();
+
+  error NoPendingBorrowerTransfer();
+
+  error NotPendingBorrower();
+
+  error BorrowerIdentityNotFound();
+
+  error BorrowerPrincipalNotRegistered();
+
+  error AmbiguousBorrowerIdentity();
+
+  error BorrowerTransferWhileSanctioned(address account);
+
   /// @dev Error thrown when reserve ratio is set to a value
   ///      that would make the market delinquent.
   error InsufficientReservesForNewLiquidityRatio();
@@ -133,6 +149,27 @@ interface IMarketEventsAndErrors {
   event AccountSanctioned(address indexed account);
 
   event WrapperRegistered(address indexed wrapper);
+
+  event BorrowerTransferRequested(
+    address indexed borrower,
+    address indexed previousPendingBorrower,
+    address indexed pendingBorrower,
+    address borrowerPrincipal,
+    address pendingBorrowerPrincipal
+  );
+
+  event BorrowerTransferCancelled(
+    address indexed borrower,
+    address indexed cancelledPendingBorrower,
+    address borrowerPrincipal
+  );
+
+  event BorrowerTransferred(
+    address indexed previousBorrower,
+    address indexed newBorrower,
+    address previousBorrowerPrincipal,
+    address indexed newBorrowerPrincipal
+  );
 
   // =====================================================================//
   //                          Withdrawl Events                            //

--- a/src/interfaces/IMarketEventsAndErrors.sol
+++ b/src/interfaces/IMarketEventsAndErrors.sol
@@ -92,6 +92,8 @@ interface IMarketEventsAndErrors {
 
   error NotPendingBorrower();
 
+  error PendingBorrowerPrincipalChanged(address expectedPrincipal, address actualPrincipal);
+
   error BorrowerIdentityNotFound();
 
   error BorrowerPrincipalNotRegistered();
@@ -157,13 +159,15 @@ interface IMarketEventsAndErrors {
     address indexed previousPendingBorrower,
     address indexed pendingBorrower,
     address borrowerPrincipal,
+    address previousPendingBorrowerPrincipal,
     address pendingBorrowerPrincipal
   );
 
   event BorrowerTransferCancelled(
     address indexed borrower,
     address indexed cancelledPendingBorrower,
-    address borrowerPrincipal
+    address borrowerPrincipal,
+    address cancelledPendingBorrowerPrincipal
   );
 
   event BorrowerTransferred(

--- a/src/interfaces/WildcatStructsAndEnums.sol
+++ b/src/interfaces/WildcatStructsAndEnums.sol
@@ -28,6 +28,7 @@ struct MarketParameters {
   HooksConfig hooks;
   // Appended so the existing 20 parameter offsets remain unchanged.
   address borrowerPrincipal;
+  address borrowerIdentityRegistry;
 }
 
 struct DeployMarketInputs {

--- a/src/interfaces/WildcatStructsAndEnums.sol
+++ b/src/interfaces/WildcatStructsAndEnums.sol
@@ -26,6 +26,8 @@ struct MarketParameters {
   address archController;
   address sphereXEngine;
   HooksConfig hooks;
+  // Appended so the existing 20 parameter offsets remain unchanged.
+  address borrowerPrincipal;
 }
 
 struct DeployMarketInputs {

--- a/src/lens/MarketData.sol
+++ b/src/lens/MarketData.sol
@@ -65,6 +65,7 @@ struct MarketDataV2_5 {
   MarketData market;
   address borrowerPrincipal;
   address pendingBorrower;
+  address pendingBorrowerPrincipal;
   address borrowerIdentityRegistry;
   OptionalUintDataV2_5 commitmentFeeBips;
   OptionalUintDataV2_5 drawnAmount;
@@ -133,6 +134,7 @@ library MarketDataLib {
     data.market.fill(market);
     data.borrowerPrincipal = market.borrowerPrincipal();
     data.pendingBorrower = market.pendingBorrower();
+    data.pendingBorrowerPrincipal = market.pendingBorrowerPrincipal();
     data.borrowerIdentityRegistry = market.borrowerIdentityRegistry();
     _tryFillOptionalUint(data.commitmentFeeBips, address(market), _COMMITMENT_FEE_BIPS_SELECTOR);
     _tryFillOptionalUint(data.drawnAmount, address(market), _DRAWN_AMOUNT_SELECTOR);

--- a/src/lens/MarketData.sol
+++ b/src/lens/MarketData.sol
@@ -63,6 +63,9 @@ struct OptionalUintDataV2_5 {
 
 struct MarketDataV2_5 {
   MarketData market;
+  address borrowerPrincipal;
+  address pendingBorrower;
+  address borrowerIdentityRegistry;
   OptionalUintDataV2_5 commitmentFeeBips;
   OptionalUintDataV2_5 drawnAmount;
 }
@@ -123,11 +126,14 @@ library MarketDataLib {
     data.delinquencyFeeBips = market.delinquencyFeeBips();
     data.delinquencyGracePeriod = market.delinquencyGracePeriod();
     address hooksAddress = data.hooksConfig.hooksAddress;
-    data.hooks.fill(hooksAddress, IHooksFactory(data.hooksFactory), data.borrower);
+    data.hooks.fill(hooksAddress, IHooksFactory(data.hooksFactory));
   }
 
   function fill(MarketDataV2_5 memory data, WildcatMarket market) internal view {
     data.market.fill(market);
+    data.borrowerPrincipal = market.borrowerPrincipal();
+    data.pendingBorrower = market.pendingBorrower();
+    data.borrowerIdentityRegistry = market.borrowerIdentityRegistry();
     _tryFillOptionalUint(data.commitmentFeeBips, address(market), _COMMITMENT_FEE_BIPS_SELECTOR);
     _tryFillOptionalUint(data.drawnAmount, address(market), _DRAWN_AMOUNT_SELECTOR);
   }

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -143,10 +143,14 @@ contract WildcatMarket is
    *      Reverts if the market is closed.
    */
   function borrow(uint256 amount) external virtual onlyBorrower nonReentrant sphereXGuardExternal {
-    // Check if the borrower is flagged as a sanctioned entity on Chainalysis.
-    // Uses `isFlaggedByChainalysis` instead of `isSanctioned` to prevent the borrower
-    // overriding their sanction status.
-    if (_isFlaggedByChainalysis(borrower())) {
+    // Check the raw Chainalysis status of both borrower identities. Sentinel overrides
+    // must not let either identity draw while flagged.
+    address currentBorrower = borrower();
+    address currentPrincipal = borrowerPrincipal();
+    if (
+      _isFlaggedByChainalysis(currentBorrower) ||
+      (currentPrincipal != currentBorrower && _isFlaggedByChainalysis(currentPrincipal))
+    ) {
       revert_BorrowWhileSanctioned();
     }
 

--- a/src/market/WildcatMarket.sol
+++ b/src/market/WildcatMarket.sol
@@ -146,7 +146,7 @@ contract WildcatMarket is
     // Check if the borrower is flagged as a sanctioned entity on Chainalysis.
     // Uses `isFlaggedByChainalysis` instead of `isSanctioned` to prevent the borrower
     // overriding their sanction status.
-    if (_isFlaggedByChainalysis(borrower)) {
+    if (_isFlaggedByChainalysis(borrower())) {
       revert_BorrowWhileSanctioned();
     }
 
@@ -231,7 +231,7 @@ contract WildcatMarket is
     } else if (currentlyHeld > totalDebts) {
       uint256 excessDebt = currentlyHeld - totalDebts;
       // Transfer excess assets to borrower
-      asset.safeTransfer(borrower, excessDebt);
+      asset.safeTransfer(borrower(), excessDebt);
       currentlyHeld -= excessDebt;
     }
     hooks.onCloseMarket(state);

--- a/src/market/WildcatMarketBase.sol
+++ b/src/market/WildcatMarketBase.sol
@@ -229,6 +229,7 @@ contract WildcatMarketBase is
     // a `MarketParameters` object without creating a duplicate allocation or unnecessarily
     // zeroing out the memory buffer.
     MarketParameters memory parameters = _getMarketParameters.asReturnsMarketParameters()();
+    if (parameters.borrower == address(0)) revert InvalidBorrower();
 
     // Set asset metadata
     asset = parameters.asset;
@@ -294,7 +295,10 @@ contract WildcatMarketBase is
     ) {
       revert InvalidBorrowerIdentityRegistry();
     }
-    if (!IWildcatArchController(_archController).isRegisteredBorrower(parameters.borrowerPrincipal)) {
+    if (
+      parameters.borrowerPrincipal == address(0) ||
+      !IWildcatArchController(_archController).isRegisteredBorrower(parameters.borrowerPrincipal)
+    ) {
       revert BorrowerPrincipalNotRegistered();
     }
     __SphereXProtectedRegisteredBase_init(parameters.sphereXEngine);

--- a/src/market/WildcatMarketBase.sol
+++ b/src/market/WildcatMarketBase.sol
@@ -409,18 +409,18 @@ contract WildcatMarketBase is
 
   /**
    * @dev Checks if `account` is flagged as a sanctioned entity by Chainalysis.
-   *      If an account is flagged mistakenly, the borrower can override their
+   *      If an account is flagged mistakenly, the principal can override their
    *      status on the sentinel and allow them to interact with the market.
    */
   function _isSanctioned(address account) internal view returns (bool result) {
-    address _borrower = borrower();
+    address _borrowerPrincipal = borrowerPrincipal();
     address _sentinel = address(sentinel);
     assembly {
       let freeMemoryPointer := mload(0x40)
       mstore(0, 0x06e74444)
-      mstore(0x20, _borrower)
+      mstore(0x20, _borrowerPrincipal)
       mstore(0x40, account)
-      // Call `sentinel.isSanctioned(borrower, account)` and revert if the call fails
+      // Call `sentinel.isSanctioned(principal, account)` and revert if the call fails
       // or does not return 32 bytes.
       if iszero(
         and(eq(returndatasize(), 0x20), staticcall(gas(), _sentinel, 0x1c, 0x44, 0, 0x20))
@@ -952,13 +952,13 @@ contract WildcatMarketBase is
     address accountAddress
   ) internal returns (address escrow) {
     address tokenAddress = address(asset);
-    address borrowerAddress = borrower();
+    address principalAddress = borrowerPrincipal();
     address sentinelAddress = address(sentinel);
 
     assembly {
       let freeMemoryPointer := mload(0x40)
       mstore(0, 0xa1054f6b)
-      mstore(0x20, borrowerAddress)
+      mstore(0x20, principalAddress)
       mstore(0x40, accountAddress)
       mstore(0x60, tokenAddress)
       if iszero(

--- a/src/market/WildcatMarketBase.sol
+++ b/src/market/WildcatMarketBase.sol
@@ -24,7 +24,7 @@ contract WildcatMarketBase is
   using LibERC20 for address;
 
   // ==================================================================== //
-  //                       Market Config (immutable)                       //
+  //                            Market Config                             //
   // ==================================================================== //
 
   /**
@@ -61,9 +61,6 @@ contract WildcatMarketBase is
   /// @dev Account with blacklist control, used for blocking sanctioned addresses.
   address public immutable sentinel;
 
-  /// @dev Account with authority to borrow assets from the market.
-  address public immutable borrower;
-
   /// @dev Factory that deployed the market. Has the ability to update the protocol fee.
   address public immutable factory;
 
@@ -72,6 +69,11 @@ contract WildcatMarketBase is
 
   /// @dev Canonical factory allowed to register this market's optional ERC-4626 wrapper.
   address public immutable wrapperFactory;
+
+  /// @dev Namespaced slot for the operational borrower. This keeps borrower
+  ///      transfers from shifting the existing market storage layout.
+  bytes32 internal constant BORROWER_STORAGE_SLOT =
+    bytes32(uint256(keccak256('wildcat.market.borrower')) - 1);
 
   /// @dev Namespaced slot for the optional canonical wrapper. Using an
   ///      unstructured slot preserves the established market storage layout.
@@ -150,6 +152,11 @@ contract WildcatMarketBase is
   MarketState internal _state;
 
   mapping(address => Account) internal _accounts;
+
+  /// @notice Current operational borrower.
+  function borrower() public view returns (address) {
+    return _getAddress(BORROWER_STORAGE_SLOT);
+  }
 
   /// @notice Canonical ERC-4626 wrapper for this market, or zero if none has been deployed.
   function registeredWrapper() public view returns (address) {
@@ -235,7 +242,7 @@ contract WildcatMarketBase is
 
     hooks = parameters.hooks;
     sentinel = parameters.sentinel;
-    borrower = parameters.borrower;
+    _setAddress(BORROWER_STORAGE_SLOT, parameters.borrower);
     feeRecipient = parameters.feeRecipient;
     wrapperFactory = parameters.wrapperFactory;
     delinquencyFeeBips = parameters.delinquencyFeeBips;
@@ -250,7 +257,7 @@ contract WildcatMarketBase is
   // ===================================================================== //
 
   modifier onlyBorrower() {
-    address _borrower = borrower;
+    address _borrower = borrower();
     assembly {
       // Equivalent to
       // if (msg.sender != borrower) revert NotApprovedBorrower();
@@ -282,7 +289,7 @@ contract WildcatMarketBase is
    *      status on the sentinel and allow them to interact with the market.
    */
   function _isSanctioned(address account) internal view returns (bool result) {
-    address _borrower = borrower;
+    address _borrower = borrower();
     address _sentinel = address(sentinel);
     assembly {
       let freeMemoryPointer := mload(0x40)
@@ -821,7 +828,7 @@ contract WildcatMarketBase is
     address accountAddress
   ) internal returns (address escrow) {
     address tokenAddress = address(asset);
-    address borrowerAddress = borrower;
+    address borrowerAddress = borrower();
     address sentinelAddress = address(sentinel);
 
     assembly {

--- a/src/market/WildcatMarketBase.sol
+++ b/src/market/WildcatMarketBase.sol
@@ -75,10 +75,17 @@ contract WildcatMarketBase is
   bytes32 internal constant BORROWER_STORAGE_SLOT =
     bytes32(uint256(keccak256('wildcat.market.borrower')) - 1);
 
+  /// @dev Namespaced slot for the market's registered principal.
+  bytes32 internal constant BORROWER_PRINCIPAL_STORAGE_SLOT =
+    bytes32(uint256(keccak256('wildcat.market.borrowerPrincipal')) - 1);
+
   /// @dev Namespaced slot for the optional canonical wrapper. Using an
   ///      unstructured slot preserves the established market storage layout.
   bytes32 internal constant REGISTERED_WRAPPER_STORAGE_SLOT =
     bytes32(uint256(keccak256('wildcat.market.registeredWrapper')) - 1);
+
+  /// @dev ABI-encoded size of `MarketParameters`, which has 21 static fields.
+  uint256 internal constant _MARKET_PARAMETERS_SIZE = 0x2a0;
 
   /// @dev Penalty fee added to interest earned by lenders, does not affect protocol fee.
   uint public immutable delinquencyFeeBips;
@@ -158,6 +165,11 @@ contract WildcatMarketBase is
     return _getAddress(BORROWER_STORAGE_SLOT);
   }
 
+  /// @notice Current registered principal for the market.
+  function borrowerPrincipal() public view returns (address) {
+    return _getAddress(BORROWER_PRINCIPAL_STORAGE_SLOT);
+  }
+
   /// @notice Canonical ERC-4626 wrapper for this market, or zero if none has been deployed.
   function registeredWrapper() public view returns (address) {
     return _getAddress(REGISTERED_WRAPPER_STORAGE_SLOT);
@@ -172,7 +184,7 @@ contract WildcatMarketBase is
   function _getMarketParameters() internal view returns (uint256 marketParametersPointer) {
     assembly {
       marketParametersPointer := mload(0x40)
-      mstore(0x40, add(marketParametersPointer, 0x280))
+      mstore(0x40, add(marketParametersPointer, _MARKET_PARAMETERS_SIZE))
       // Write the selector for IHooksFactory.getMarketParameters
       mstore(0x00, 0x04032dbb)
       // Call `getMarketParameters` and copy the returned struct to the allocated memory
@@ -181,8 +193,15 @@ contract WildcatMarketBase is
       // the factory contract which will only ever return the prepared market parameters.
       if iszero(
         and(
-          eq(returndatasize(), 0x280),
-          staticcall(gas(), caller(), 0x1c, 0x04, marketParametersPointer, 0x280)
+          eq(returndatasize(), _MARKET_PARAMETERS_SIZE),
+          staticcall(
+            gas(),
+            caller(),
+            0x1c,
+            0x04,
+            marketParametersPointer,
+            _MARKET_PARAMETERS_SIZE
+          )
         )
       ) {
         revert(0, 0)
@@ -243,6 +262,7 @@ contract WildcatMarketBase is
     hooks = parameters.hooks;
     sentinel = parameters.sentinel;
     _setAddress(BORROWER_STORAGE_SLOT, parameters.borrower);
+    _setAddress(BORROWER_PRINCIPAL_STORAGE_SLOT, parameters.borrowerPrincipal);
     feeRecipient = parameters.feeRecipient;
     wrapperFactory = parameters.wrapperFactory;
     delinquencyFeeBips = parameters.delinquencyFeeBips;

--- a/src/market/WildcatMarketBase.sol
+++ b/src/market/WildcatMarketBase.sol
@@ -4,6 +4,8 @@ pragma solidity >=0.8.20;
 import '../ReentrancyGuard.sol';
 import '../spherex/SphereXProtectedRegisteredBase.sol';
 import '../interfaces/IMarketEventsAndErrors.sol';
+import '../interfaces/IBorrowerIdentityRegistry.sol';
+import '../interfaces/IWildcatArchController.sol';
 import '../IHooksFactory.sol';
 import '../libraries/FeeMath.sol';
 import '../libraries/MarketErrors.sol';
@@ -70,6 +72,9 @@ contract WildcatMarketBase is
   /// @dev Canonical factory allowed to register this market's optional ERC-4626 wrapper.
   address public immutable wrapperFactory;
 
+  /// @dev Registry that resolves borrower accounts to registered principals.
+  address public immutable borrowerIdentityRegistry;
+
   /// @dev Namespaced slot for the operational borrower. This keeps borrower
   ///      transfers from shifting the existing market storage layout.
   bytes32 internal constant BORROWER_STORAGE_SLOT =
@@ -79,13 +84,17 @@ contract WildcatMarketBase is
   bytes32 internal constant BORROWER_PRINCIPAL_STORAGE_SLOT =
     bytes32(uint256(keccak256('wildcat.market.borrowerPrincipal')) - 1);
 
+  /// @dev Namespaced slot for the pending borrower.
+  bytes32 internal constant PENDING_BORROWER_STORAGE_SLOT =
+    bytes32(uint256(keccak256('wildcat.market.pendingBorrower')) - 1);
+
   /// @dev Namespaced slot for the optional canonical wrapper. Using an
   ///      unstructured slot preserves the established market storage layout.
   bytes32 internal constant REGISTERED_WRAPPER_STORAGE_SLOT =
     bytes32(uint256(keccak256('wildcat.market.registeredWrapper')) - 1);
 
-  /// @dev ABI-encoded size of `MarketParameters`, which has 21 static fields.
-  uint256 internal constant _MARKET_PARAMETERS_SIZE = 0x2a0;
+  /// @dev ABI-encoded size of `MarketParameters`, which has 22 static fields.
+  uint256 internal constant _MARKET_PARAMETERS_SIZE = 0x2c0;
 
   /// @dev Penalty fee added to interest earned by lenders, does not affect protocol fee.
   uint public immutable delinquencyFeeBips;
@@ -168,6 +177,11 @@ contract WildcatMarketBase is
   /// @notice Current registered principal for the market.
   function borrowerPrincipal() public view returns (address) {
     return _getAddress(BORROWER_PRINCIPAL_STORAGE_SLOT);
+  }
+
+  /// @notice Address that can accept the pending borrower transfer.
+  function pendingBorrower() public view returns (address) {
+    return _getAddress(PENDING_BORROWER_STORAGE_SLOT);
   }
 
   /// @notice Canonical ERC-4626 wrapper for this market, or zero if none has been deployed.
@@ -265,10 +279,24 @@ contract WildcatMarketBase is
     _setAddress(BORROWER_PRINCIPAL_STORAGE_SLOT, parameters.borrowerPrincipal);
     feeRecipient = parameters.feeRecipient;
     wrapperFactory = parameters.wrapperFactory;
+    borrowerIdentityRegistry = parameters.borrowerIdentityRegistry;
     delinquencyFeeBips = parameters.delinquencyFeeBips;
     delinquencyGracePeriod = parameters.delinquencyGracePeriod;
     withdrawalBatchDuration = parameters.withdrawalBatchDuration;
     _archController = parameters.archController;
+    (bool registryCallSucceeded, bytes memory registryResult) = borrowerIdentityRegistry.staticcall(
+      abi.encodeCall(IBorrowerIdentityRegistry.archController, ())
+    );
+    if (
+      !registryCallSucceeded ||
+      registryResult.length != 0x20 ||
+      abi.decode(registryResult, (address)) != _archController
+    ) {
+      revert InvalidBorrowerIdentityRegistry();
+    }
+    if (!IWildcatArchController(_archController).isRegisteredBorrower(parameters.borrowerPrincipal)) {
+      revert BorrowerPrincipalNotRegistered();
+    }
     __SphereXProtectedRegisteredBase_init(parameters.sphereXEngine);
   }
 
@@ -287,6 +315,82 @@ contract WildcatMarketBase is
       }
     }
     _;
+  }
+
+  // ===================================================================== //
+  //                         Borrower Transfer                             //
+  // ===================================================================== //
+
+  function _validateBorrowerTransferTarget(
+    address newBorrower
+  ) internal view returns (address newBorrowerPrincipal) {
+    address currentBorrower = borrower();
+    if (newBorrower == address(0) || newBorrower == currentBorrower) {
+      revert InvalidBorrowerTransferTarget();
+    }
+
+    newBorrowerPrincipal = IBorrowerIdentityRegistry(borrowerIdentityRegistry).resolveBorrower(
+      newBorrower
+    );
+
+    address currentBorrowerPrincipal = borrowerPrincipal();
+    if (_isFlaggedByChainalysis(currentBorrower)) {
+      revert BorrowerTransferWhileSanctioned(currentBorrower);
+    }
+    if (
+      currentBorrowerPrincipal != currentBorrower &&
+      _isFlaggedByChainalysis(currentBorrowerPrincipal)
+    ) {
+      revert BorrowerTransferWhileSanctioned(currentBorrowerPrincipal);
+    }
+    if (_isFlaggedByChainalysis(newBorrower)) {
+      revert BorrowerTransferWhileSanctioned(newBorrower);
+    }
+    if (newBorrowerPrincipal != newBorrower && _isFlaggedByChainalysis(newBorrowerPrincipal)) {
+      revert BorrowerTransferWhileSanctioned(newBorrowerPrincipal);
+    }
+  }
+
+  function requestBorrowerTransfer(
+    address newBorrower
+  ) external onlyBorrower nonReentrant sphereXGuardExternal {
+    address newBorrowerPrincipal = _validateBorrowerTransferTarget(newBorrower);
+    address previousPendingBorrower = pendingBorrower();
+    _setAddress(PENDING_BORROWER_STORAGE_SLOT, newBorrower);
+    emit BorrowerTransferRequested(
+      msg.sender,
+      previousPendingBorrower,
+      newBorrower,
+      borrowerPrincipal(),
+      newBorrowerPrincipal
+    );
+  }
+
+  function cancelBorrowerTransfer() external onlyBorrower nonReentrant sphereXGuardExternal {
+    address cancelledPendingBorrower = pendingBorrower();
+    if (cancelledPendingBorrower == address(0)) revert NoPendingBorrowerTransfer();
+    _setAddress(PENDING_BORROWER_STORAGE_SLOT, address(0));
+    emit BorrowerTransferCancelled(msg.sender, cancelledPendingBorrower, borrowerPrincipal());
+  }
+
+  function acceptBorrowerTransfer() external nonReentrant sphereXGuardExternal {
+    address newBorrower = pendingBorrower();
+    if (msg.sender != newBorrower) revert NotPendingBorrower();
+
+    address newBorrowerPrincipal = _validateBorrowerTransferTarget(newBorrower);
+    address previousBorrower = borrower();
+    address previousBorrowerPrincipal = borrowerPrincipal();
+
+    _setAddress(PENDING_BORROWER_STORAGE_SLOT, address(0));
+    _setAddress(BORROWER_STORAGE_SLOT, newBorrower);
+    _setAddress(BORROWER_PRINCIPAL_STORAGE_SLOT, newBorrowerPrincipal);
+
+    emit BorrowerTransferred(
+      previousBorrower,
+      newBorrower,
+      previousBorrowerPrincipal,
+      newBorrowerPrincipal
+    );
   }
 
   // ===================================================================== //

--- a/src/market/WildcatMarketBase.sol
+++ b/src/market/WildcatMarketBase.sol
@@ -88,6 +88,10 @@ contract WildcatMarketBase is
   bytes32 internal constant PENDING_BORROWER_STORAGE_SLOT =
     bytes32(uint256(keccak256('wildcat.market.pendingBorrower')) - 1);
 
+  /// @dev Namespaced slot for the principal resolved when a transfer is requested.
+  bytes32 internal constant PENDING_BORROWER_PRINCIPAL_STORAGE_SLOT =
+    bytes32(uint256(keccak256('wildcat.market.pendingBorrowerPrincipal')) - 1);
+
   /// @dev Namespaced slot for the optional canonical wrapper. Using an
   ///      unstructured slot preserves the established market storage layout.
   bytes32 internal constant REGISTERED_WRAPPER_STORAGE_SLOT =
@@ -182,6 +186,11 @@ contract WildcatMarketBase is
   /// @notice Address that can accept the pending borrower transfer.
   function pendingBorrower() public view returns (address) {
     return _getAddress(PENDING_BORROWER_STORAGE_SLOT);
+  }
+
+  /// @notice Principal resolved for the pending borrower when the transfer was requested.
+  function pendingBorrowerPrincipal() public view returns (address) {
+    return _getAddress(PENDING_BORROWER_PRINCIPAL_STORAGE_SLOT);
   }
 
   /// @notice Canonical ERC-4626 wrapper for this market, or zero if none has been deployed.
@@ -326,18 +335,25 @@ contract WildcatMarketBase is
   // ===================================================================== //
 
   function _validateBorrowerTransferTarget(
-    address newBorrower
+    address newBorrower,
+    address expectedPrincipal
   ) internal view returns (address newBorrowerPrincipal) {
     address currentBorrower = borrower();
-    if (newBorrower == address(0) || newBorrower == currentBorrower) {
-      revert InvalidBorrowerTransferTarget();
-    }
+    if (newBorrower == address(0)) revert InvalidBorrowerTransferTarget();
 
     newBorrowerPrincipal = IBorrowerIdentityRegistry(borrowerIdentityRegistry).resolveBorrower(
       newBorrower
     );
 
     address currentBorrowerPrincipal = borrowerPrincipal();
+    if (expectedPrincipal != address(0) && newBorrowerPrincipal != expectedPrincipal) {
+      revert PendingBorrowerPrincipalChanged(expectedPrincipal, newBorrowerPrincipal);
+    }
+    if (
+      newBorrower == currentBorrower && newBorrowerPrincipal == currentBorrowerPrincipal
+    ) {
+      revert InvalidBorrowerTransferTarget();
+    }
     if (_isFlaggedByChainalysis(currentBorrower)) {
       revert BorrowerTransferWhileSanctioned(currentBorrower);
     }
@@ -358,14 +374,17 @@ contract WildcatMarketBase is
   function requestBorrowerTransfer(
     address newBorrower
   ) external onlyBorrower nonReentrant sphereXGuardExternal {
-    address newBorrowerPrincipal = _validateBorrowerTransferTarget(newBorrower);
+    address newBorrowerPrincipal = _validateBorrowerTransferTarget(newBorrower, address(0));
     address previousPendingBorrower = pendingBorrower();
+    address previousPendingBorrowerPrincipal = pendingBorrowerPrincipal();
     _setAddress(PENDING_BORROWER_STORAGE_SLOT, newBorrower);
+    _setAddress(PENDING_BORROWER_PRINCIPAL_STORAGE_SLOT, newBorrowerPrincipal);
     emit BorrowerTransferRequested(
       msg.sender,
       previousPendingBorrower,
       newBorrower,
       borrowerPrincipal(),
+      previousPendingBorrowerPrincipal,
       newBorrowerPrincipal
     );
   }
@@ -373,19 +392,31 @@ contract WildcatMarketBase is
   function cancelBorrowerTransfer() external onlyBorrower nonReentrant sphereXGuardExternal {
     address cancelledPendingBorrower = pendingBorrower();
     if (cancelledPendingBorrower == address(0)) revert NoPendingBorrowerTransfer();
+    address cancelledPendingBorrowerPrincipal = pendingBorrowerPrincipal();
     _setAddress(PENDING_BORROWER_STORAGE_SLOT, address(0));
-    emit BorrowerTransferCancelled(msg.sender, cancelledPendingBorrower, borrowerPrincipal());
+    _setAddress(PENDING_BORROWER_PRINCIPAL_STORAGE_SLOT, address(0));
+    emit BorrowerTransferCancelled(
+      msg.sender,
+      cancelledPendingBorrower,
+      borrowerPrincipal(),
+      cancelledPendingBorrowerPrincipal
+    );
   }
 
   function acceptBorrowerTransfer() external nonReentrant sphereXGuardExternal {
     address newBorrower = pendingBorrower();
     if (msg.sender != newBorrower) revert NotPendingBorrower();
 
-    address newBorrowerPrincipal = _validateBorrowerTransferTarget(newBorrower);
+    address expectedPrincipal = pendingBorrowerPrincipal();
+    address newBorrowerPrincipal = _validateBorrowerTransferTarget(
+      newBorrower,
+      expectedPrincipal
+    );
     address previousBorrower = borrower();
     address previousBorrowerPrincipal = borrowerPrincipal();
 
     _setAddress(PENDING_BORROWER_STORAGE_SLOT, address(0));
+    _setAddress(PENDING_BORROWER_PRINCIPAL_STORAGE_SLOT, address(0));
     _setAddress(BORROWER_STORAGE_SLOT, newBorrower);
     _setAddress(BORROWER_PRINCIPAL_STORAGE_SLOT, newBorrowerPrincipal);
 

--- a/src/vault/Wildcat4626Wrapper.sol
+++ b/src/vault/Wildcat4626Wrapper.sol
@@ -15,6 +15,8 @@ interface IWildcatMarketToken is IERC20Metadata {
 
   function borrower() external view returns (address);
 
+  function borrowerPrincipal() external view returns (address);
+
   function maxTotalSupply() external view returns (uint256);
 
   function sentinel() external view returns (address);
@@ -48,7 +50,6 @@ contract Wildcat4626Wrapper is ERC4626, ReentrancyGuard {
   error InsolventWrapper(uint256 scaledBacking, uint256 shareSupply);
 
   IWildcatMarketToken public immutable wrappedMarket;
-  address public immutable marketOwner;
   IWildcatSanctionsSentinel public immutable sanctionsSentinel;
 
   uint8 private immutable _decimals;
@@ -63,11 +64,11 @@ contract Wildcat4626Wrapper is ERC4626, ReentrancyGuard {
 
     wrappedMarket = IWildcatMarketToken(marketAddress);
     if (msg.sender != wrappedMarket.wrapperFactory()) revert NotWrapperFactory();
-    address owner = wrappedMarket.borrower();
-    if (owner == address(0)) revert ZeroAddress();
+    address currentBorrower = wrappedMarket.borrower();
+    if (currentBorrower == address(0)) revert ZeroAddress();
+    if (wrappedMarket.borrowerPrincipal() == address(0)) revert ZeroAddress();
     address sentinel = wrappedMarket.sentinel();
     if (sentinel == address(0)) revert ZeroAddress();
-    marketOwner = owner;
     sanctionsSentinel = IWildcatSanctionsSentinel(sentinel);
     _decimals = wrappedMarket.decimals();
 
@@ -124,6 +125,11 @@ contract Wildcat4626Wrapper is ERC4626, ReentrancyGuard {
   /// @notice Address of the wrapped Wildcat market token.
   function market() public view returns (address) {
     return address(wrappedMarket);
+  }
+
+  /// @notice Current operational borrower of the wrapped market.
+  function marketOwner() public view returns (address) {
+    return wrappedMarket.borrower();
   }
 
   /// @notice Alias for the wrapped market so integrators can treat it as the ERC-4626 asset.
@@ -412,7 +418,11 @@ contract Wildcat4626Wrapper is ERC4626, ReentrancyGuard {
     uint256 shares = balanceOf(account);
     if (shares == 0) return;
 
-    address escrow = sanctionsSentinel.createEscrow(marketOwner, account, address(this));
+    address escrow = sanctionsSentinel.createEscrow(
+      wrappedMarket.borrowerPrincipal(),
+      account,
+      address(this)
+    );
     _transfer(account, escrow, shares);
     emit SanctionedAccountSharesSentToEscrow(account, escrow, shares);
   }
@@ -420,7 +430,7 @@ contract Wildcat4626Wrapper is ERC4626, ReentrancyGuard {
   /// @notice Sweep arbitrary ERC20 balances and any stranded wrapped market tokens.
   /// @dev For wrapped market sweeps, only the surplus over total supply is sweepable.
   function sweep(address token, address to) external nonReentrant returns (uint256 amount) {
-    if (msg.sender != marketOwner) revert NotMarketOwner();
+    if (msg.sender != wrappedMarket.borrower()) revert NotMarketOwner();
     if (token == address(0) || to == address(0)) revert ZeroAddress();
     _checkNotSanctioned(to);
 
@@ -491,7 +501,23 @@ contract Wildcat4626Wrapper is ERC4626, ReentrancyGuard {
   }
 
   function _isSanctioned(address account) internal view returns (bool) {
-    return account != address(0) && sanctionsSentinel.isSanctioned(marketOwner, account);
+    return
+      account != address(0) &&
+      sanctionsSentinel.isSanctioned(wrappedMarket.borrowerPrincipal(), account);
+  }
+
+  /// @dev Checks `from` against the canonical escrow for `account` under its original principal.
+  function _isEscrowRelease(address from, address account) internal view returns (bool) {
+    address escrowPrincipal;
+    assembly {
+      mstore(0, 0x7df1f1b9) // borrower()
+      if and(eq(returndatasize(), 0x20), staticcall(gas(), from, 0x1c, 0x04, 0, 0x20)) {
+        escrowPrincipal := and(mload(0), 0xffffffffffffffffffffffffffffffffffffffff)
+      }
+    }
+    return
+      escrowPrincipal != address(0) &&
+      sanctionsSentinel.getEscrowAddress(escrowPrincipal, account, address(this)) == from;
   }
 
   function _isSolvent() internal view returns (bool) {
@@ -521,13 +547,23 @@ contract Wildcat4626Wrapper is ERC4626, ReentrancyGuard {
   }
 
   function _beforeTokenTransfer(address from, address to, uint256 amount) internal override {
-    if (_isSanctioned(from)) {
-      address escrow = sanctionsSentinel.getEscrowAddress(marketOwner, from, address(this));
-      if (to != escrow) revert SanctionedAccount(from);
-    } else {
+    bool fromIsSanctioned = _isSanctioned(from);
+    bool toIsSanctioned = _isSanctioned(to);
+    if ((fromIsSanctioned || toIsSanctioned) && _isEscrowRelease(from, to)) {
       _requireOperational();
+    } else {
+      if (fromIsSanctioned) {
+        address escrow = sanctionsSentinel.getEscrowAddress(
+          wrappedMarket.borrowerPrincipal(),
+          from,
+          address(this)
+        );
+        if (to != escrow) revert SanctionedAccount(from);
+      } else {
+        _requireOperational();
+      }
+      if (toIsSanctioned) revert SanctionedAccount(to);
     }
-    _checkNotSanctioned(to);
     if (amount == 0) {
       return;
     }

--- a/test/BorrowerAccountOrigination.t.sol
+++ b/test/BorrowerAccountOrigination.t.sol
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.20;
+
+import 'forge-std/Test.sol';
+import 'src/WildcatArchController.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
+import 'src/HooksFactory.sol';
+import 'src/HooksFactoryRevolving.sol';
+import 'src/access/BaseAccessControls.sol';
+import 'src/access/OpenTermHooks.sol';
+import 'src/interfaces/IBorrowerIdentityRegistry.sol';
+import 'src/interfaces/IMarketEventsAndErrors.sol';
+import 'src/libraries/LibStoredInitCode.sol';
+import 'src/market/WildcatMarket.sol';
+import 'src/market/WildcatMarketRevolving.sol';
+import { MockERC20 } from 'solmate/test/utils/mocks/MockERC20.sol';
+
+// Deliberately has no market or factory ABI. v2.5 only authenticates the account address.
+contract OriginationTestBorrowerAccount {}
+
+contract OriginationTestBorrowerAccountFactory {
+  IBorrowerIdentityRegistry public immutable registry;
+
+  constructor(address registry_) {
+    registry = IBorrowerIdentityRegistry(registry_);
+  }
+
+  function deployAccount(address principal) external returns (address account) {
+    account = address(new OriginationTestBorrowerAccount());
+    registry.registerBorrowerAccount(account, principal);
+  }
+}
+
+contract BorrowerAccountOriginationTest is Test {
+  WildcatArchController internal archController;
+  WildcatBorrowerIdentityRegistry internal borrowerIdentityRegistry;
+  OriginationTestBorrowerAccountFactory internal accountFactory;
+  HooksFactory internal standardFactory;
+  HooksFactoryRevolving internal revolvingFactory;
+  MockERC20 internal asset;
+
+  address internal hooksTemplate;
+  address internal borrowerAccount;
+
+  address internal constant principal = address(0xA11CE);
+  address internal constant secondPrincipal = address(0xB0B);
+  address internal constant sanctionsSentinel = address(0x51);
+
+  function setUp() public {
+    archController = new WildcatArchController();
+    borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(address(archController));
+    accountFactory = new OriginationTestBorrowerAccountFactory(
+      address(borrowerIdentityRegistry)
+    );
+    asset = new MockERC20('Underlying', 'UND', 18);
+
+    archController.registerBorrower(principal);
+    borrowerIdentityRegistry.addAccountFactory(address(accountFactory));
+    borrowerAccount = accountFactory.deployAccount(principal);
+
+    hooksTemplate = LibStoredInitCode.deployInitCode(type(OpenTermHooks).creationCode);
+    standardFactory = _deployStandardFactory();
+    revolvingFactory = _deployRevolvingFactory();
+  }
+
+  function _deployStandardFactory() internal returns (HooksFactory factory) {
+    bytes memory marketInitCode = type(WildcatMarket).creationCode;
+    factory = new HooksFactory(
+      address(archController),
+      sanctionsSentinel,
+      address(this),
+      LibStoredInitCode.deployInitCode(marketInitCode),
+      uint256(keccak256(marketInitCode)),
+      address(borrowerIdentityRegistry)
+    );
+    archController.registerControllerFactory(address(factory));
+    factory.registerWithArchController();
+    factory.addHooksTemplate(hooksTemplate, 'Open Term', address(0), address(0), 0, 0);
+  }
+
+  function _deployRevolvingFactory() internal returns (HooksFactoryRevolving factory) {
+    bytes memory marketInitCode = type(WildcatMarketRevolving).creationCode;
+    factory = new HooksFactoryRevolving(
+      address(archController),
+      sanctionsSentinel,
+      address(this),
+      LibStoredInitCode.deployInitCode(marketInitCode),
+      uint256(keccak256(marketInitCode)),
+      address(borrowerIdentityRegistry)
+    );
+    archController.registerControllerFactory(address(factory));
+    factory.registerWithArchController();
+    factory.addHooksTemplate(hooksTemplate, 'Open Term', address(0), address(0), 0, 0);
+  }
+
+  function _marketInputs(address hooksInstance) internal view returns (DeployMarketInputs memory) {
+    return
+      DeployMarketInputs({
+        asset: address(asset),
+        namePrefix: 'Wildcat ',
+        symbolPrefix: 'wc',
+        maxTotalSupply: 1_000_000e18,
+        annualInterestBips: 1_000,
+        delinquencyFeeBips: 100,
+        withdrawalBatchDuration: 1 days,
+        reserveRatioBips: 1_000,
+        delinquencyGracePeriod: 1 days,
+        hooks: EmptyHooksConfig.setHooksAddress(hooksInstance)
+      });
+  }
+
+  function _assertMarketIdentity(
+    address marketAddress,
+    address hooksInstance,
+    address expectedBorrower,
+    address expectedPrincipal
+  ) internal view {
+    WildcatMarket market = WildcatMarket(marketAddress);
+    assertEq(market.borrower(), expectedBorrower, 'operational borrower');
+    assertEq(market.borrowerPrincipal(), expectedPrincipal, 'borrower principal');
+    assertEq(OpenTermHooks(hooksInstance).borrower(), expectedPrincipal, 'hook borrower');
+  }
+
+  function _transferAccountPrincipal(address newPrincipal) internal {
+    archController.registerBorrower(newPrincipal);
+    vm.prank(principal);
+    borrowerIdentityRegistry.requestBorrowerAccountPrincipalTransfer(
+      borrowerAccount,
+      newPrincipal
+    );
+    vm.prank(newPrincipal);
+    borrowerIdentityRegistry.acceptBorrowerAccountPrincipalTransfer(borrowerAccount);
+  }
+
+  function _assertAccountAuthority(address marketAddress) internal {
+    WildcatMarket market = WildcatMarket(marketAddress);
+    uint256 updatedMaximumSupply = market.maxTotalSupply() - 1;
+
+    vm.prank(principal);
+    vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
+    market.setMaxTotalSupply(updatedMaximumSupply);
+
+    vm.prank(borrowerAccount);
+    market.setMaxTotalSupply(updatedMaximumSupply);
+    assertEq(market.maxTotalSupply(), updatedMaximumSupply);
+  }
+
+  function test_standardAccountDeploysHookAndMarket() external {
+    vm.startPrank(borrowerAccount);
+    address hooksInstance = standardFactory.deployHooksInstance(hooksTemplate, '');
+    address market = standardFactory.deployMarket(
+      _marketInputs(hooksInstance),
+      '',
+      bytes32(uint256(1)),
+      address(0),
+      0
+    );
+    vm.stopPrank();
+
+    _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
+    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 1);
+    assertEq(standardFactory.getHooksInstancesCountForBorrower(borrowerAccount), 0);
+    _assertAccountAuthority(market);
+  }
+
+  function test_revolvingAccountDeploysHookAndMarket() external {
+    vm.startPrank(borrowerAccount);
+    address hooksInstance = revolvingFactory.deployHooksInstance(hooksTemplate, '');
+    address market = revolvingFactory.deployMarket(
+      _marketInputs(hooksInstance),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(1)),
+      address(0),
+      0
+    );
+    vm.stopPrank();
+
+    _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
+    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 1);
+    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(borrowerAccount), 0);
+    _assertAccountAuthority(market);
+  }
+
+  function test_standardAccountDeploysMarketAndHookTogether() external {
+    vm.prank(borrowerAccount);
+    (address market, address hooksInstance) = standardFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      bytes32(uint256(2)),
+      address(0),
+      0
+    );
+
+    _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
+    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 1);
+  }
+
+  function test_revolvingAccountDeploysMarketAndHookTogether() external {
+    vm.prank(borrowerAccount);
+    (address market, address hooksInstance) = revolvingFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(2)),
+      address(0),
+      0
+    );
+
+    _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
+    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 1);
+  }
+
+  function test_accountPaysOriginationFees() external {
+    address feeRecipient = address(0xFEE);
+    uint80 originationFeeAmount = 1e18;
+    standardFactory.updateHooksTemplateFees(
+      hooksTemplate,
+      feeRecipient,
+      address(asset),
+      originationFeeAmount,
+      0
+    );
+    revolvingFactory.updateHooksTemplateFees(
+      hooksTemplate,
+      feeRecipient,
+      address(asset),
+      originationFeeAmount,
+      0
+    );
+    asset.mint(borrowerAccount, uint256(originationFeeAmount) * 2);
+
+    vm.startPrank(borrowerAccount);
+    asset.approve(address(standardFactory), originationFeeAmount);
+    standardFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      bytes32(uint256(20)),
+      address(asset),
+      originationFeeAmount
+    );
+    asset.approve(address(revolvingFactory), originationFeeAmount);
+    revolvingFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(20)),
+      address(asset),
+      originationFeeAmount
+    );
+    vm.stopPrank();
+
+    assertEq(asset.balanceOf(feeRecipient), uint256(originationFeeAmount) * 2);
+    assertEq(asset.balanceOf(borrowerAccount), 0);
+    assertEq(asset.balanceOf(principal), 0);
+  }
+
+  function test_accountOriginationUsesCurrentRegistryPrincipal() external {
+    _transferAccountPrincipal(secondPrincipal);
+
+    vm.prank(borrowerAccount);
+    (address standardMarket, address standardHooks) = standardFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      bytes32(uint256(3)),
+      address(0),
+      0
+    );
+    vm.prank(borrowerAccount);
+    (address revolvingMarket, address revolvingHooks) = revolvingFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(3)),
+      address(0),
+      0
+    );
+
+    _assertMarketIdentity(
+      standardMarket,
+      standardHooks,
+      borrowerAccount,
+      secondPrincipal
+    );
+    _assertMarketIdentity(
+      revolvingMarket,
+      revolvingHooks,
+      borrowerAccount,
+      secondPrincipal
+    );
+  }
+
+  function test_accountsUnderOnePrincipalCanShareHooks() external {
+    address secondAccount = accountFactory.deployAccount(principal);
+
+    vm.prank(principal);
+    address standardHooks = standardFactory.deployHooksInstance(hooksTemplate, '');
+    vm.prank(borrowerAccount);
+    address firstStandardMarket = standardFactory.deployMarket(
+      _marketInputs(standardHooks),
+      '',
+      bytes32(uint256(10)),
+      address(0),
+      0
+    );
+    vm.prank(secondAccount);
+    address secondStandardMarket = standardFactory.deployMarket(
+      _marketInputs(standardHooks),
+      '',
+      bytes32(uint256(11)),
+      address(0),
+      0
+    );
+
+    vm.prank(principal);
+    address revolvingHooks = revolvingFactory.deployHooksInstance(hooksTemplate, '');
+    vm.prank(borrowerAccount);
+    address firstRevolvingMarket = revolvingFactory.deployMarket(
+      _marketInputs(revolvingHooks),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(10)),
+      address(0),
+      0
+    );
+    vm.prank(secondAccount);
+    address secondRevolvingMarket = revolvingFactory.deployMarket(
+      _marketInputs(revolvingHooks),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(11)),
+      address(0),
+      0
+    );
+
+    _assertMarketIdentity(firstStandardMarket, standardHooks, borrowerAccount, principal);
+    _assertMarketIdentity(secondStandardMarket, standardHooks, secondAccount, principal);
+    _assertMarketIdentity(firstRevolvingMarket, revolvingHooks, borrowerAccount, principal);
+    _assertMarketIdentity(secondRevolvingMarket, revolvingHooks, secondAccount, principal);
+    assertEq(standardFactory.getMarketsForHooksInstanceCount(standardHooks), 2);
+    assertEq(revolvingFactory.getMarketsForHooksInstanceCount(revolvingHooks), 2);
+  }
+
+  function test_accountsUnderOnePrincipalShareHookDeploymentSequence() external {
+    address secondAccount = accountFactory.deployAccount(principal);
+
+    vm.prank(borrowerAccount);
+    address firstStandardHooks = standardFactory.deployHooksInstance(hooksTemplate, '');
+    vm.prank(secondAccount);
+    address secondStandardHooks = standardFactory.deployHooksInstance(hooksTemplate, '');
+
+    vm.prank(borrowerAccount);
+    address firstRevolvingHooks = revolvingFactory.deployHooksInstance(hooksTemplate, '');
+    vm.prank(secondAccount);
+    address secondRevolvingHooks = revolvingFactory.deployHooksInstance(hooksTemplate, '');
+
+    assertTrue(firstStandardHooks != secondStandardHooks);
+    assertTrue(firstRevolvingHooks != secondRevolvingHooks);
+    assertEq(OpenTermHooks(firstStandardHooks).borrower(), principal);
+    assertEq(OpenTermHooks(secondStandardHooks).borrower(), principal);
+    assertEq(OpenTermHooks(firstRevolvingHooks).borrower(), principal);
+    assertEq(OpenTermHooks(secondRevolvingHooks).borrower(), principal);
+    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 2);
+    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 2);
+  }
+
+  function test_accountCannotOriginateAfterPrincipalRemoval() external {
+    archController.removeBorrower(principal);
+
+    vm.prank(borrowerAccount);
+    vm.expectRevert(IHooksFactoryEventsAndErrors.NotApprovedBorrower.selector);
+    standardFactory.deployHooksInstance(hooksTemplate, '');
+
+    vm.prank(borrowerAccount);
+    vm.expectRevert(IHooksFactoryEventsAndErrors.NotApprovedBorrower.selector);
+    revolvingFactory.deployHooksInstance(hooksTemplate, '');
+
+    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 0);
+    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 0);
+  }
+
+  function test_accountOriginationSurvivesAccountFactoryRemoval() external {
+    borrowerIdentityRegistry.removeAccountFactory(address(accountFactory));
+
+    vm.prank(borrowerAccount);
+    (address standardMarket, address standardHooks) = standardFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      bytes32(uint256(12)),
+      address(0),
+      0
+    );
+    vm.prank(borrowerAccount);
+    (address revolvingMarket, address revolvingHooks) = revolvingFactory.deployMarketAndHooks(
+      hooksTemplate,
+      '',
+      _marketInputs(address(0)),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(12)),
+      address(0),
+      0
+    );
+
+    _assertMarketIdentity(standardMarket, standardHooks, borrowerAccount, principal);
+    _assertMarketIdentity(revolvingMarket, revolvingHooks, borrowerAccount, principal);
+  }
+
+  function test_accountCannotUseHookFromAnotherPrincipal() external {
+    archController.registerBorrower(secondPrincipal);
+
+    vm.prank(secondPrincipal);
+    address standardHooks = standardFactory.deployHooksInstance(hooksTemplate, '');
+    vm.prank(borrowerAccount);
+    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    standardFactory.deployMarket(
+      _marketInputs(standardHooks),
+      '',
+      bytes32(uint256(4)),
+      address(0),
+      0
+    );
+
+    vm.prank(secondPrincipal);
+    address revolvingHooks = revolvingFactory.deployHooksInstance(hooksTemplate, '');
+    vm.prank(borrowerAccount);
+    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    revolvingFactory.deployMarket(
+      _marketInputs(revolvingHooks),
+      '',
+      abi.encode(uint8(1), uint16(100)),
+      bytes32(uint256(4)),
+      address(0),
+      0
+    );
+  }
+}

--- a/test/HooksFactory.t.sol
+++ b/test/HooksFactory.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.19;
 
 import 'forge-std/Test.sol';
 import 'src/WildcatArchController.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
 import 'src/HooksFactory.sol';
 import 'src/IHooksFactory.sol';
 import 'src/libraries/LibStoredInitCode.sol';
@@ -47,6 +48,7 @@ contract BrokenHooksTemplate {
 
 contract HooksFactoryTest is Test, Assertions {
   WildcatArchController archController;
+  WildcatBorrowerIdentityRegistry borrowerIdentityRegistry;
   IHooksFactory hooksFactory;
   address internal immutable MockHooksTemplate =
     LibStoredInitCode.deployInitCode(type(MockHooks).creationCode);
@@ -87,6 +89,7 @@ contract HooksFactoryTest is Test, Assertions {
 
   function setUp() public {
     archController = new WildcatArchController();
+    borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(address(archController));
 
     (address marketTemplate, uint256 marketInitCodeHash) = _storeMarketInitCode();
     hooksFactory = new HooksFactory(
@@ -94,13 +97,15 @@ contract HooksFactoryTest is Test, Assertions {
       sanctionsSentinel,
       address(this),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
     // hooksTemplate = LibStoredInitCode.deployInitCode(type(MockHooks).creationCode);
     archController.registerControllerFactory(address(hooksFactory));
     hooksFactory.registerWithArchController();
     assertEq(hooksFactory.name(), 'WildcatHooksFactory');
     assertEq(hooksFactory.archController(), address(archController));
+    assertEq(hooksFactory.borrowerIdentityRegistry(), address(borrowerIdentityRegistry));
   }
 
   // ========================================================================== //
@@ -1092,7 +1097,8 @@ contract HooksFactoryTest is Test, Assertions {
       sanctionsSentinel,
       address(this),
       marketTemplate,
-      uint256(keccak256('stale market init code hash'))
+      uint256(keccak256('stale market init code hash')),
+      address(borrowerIdentityRegistry)
     );
     archController.registerControllerFactory(address(badFactory));
     badFactory.registerWithArchController();

--- a/test/HooksFactoryRevolving.t.sol
+++ b/test/HooksFactoryRevolving.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.19;
 
 import 'forge-std/Test.sol';
 import 'src/WildcatArchController.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
 import 'src/HooksFactoryRevolving.sol';
 import 'src/IHooksFactoryRevolving.sol';
 import 'src/libraries/LibStoredInitCode.sol';
@@ -22,6 +23,7 @@ contract BrokenHooksTemplate {
 
 contract HooksFactoryRevolvingTest is Test, Assertions {
   WildcatArchController archController;
+  WildcatBorrowerIdentityRegistry borrowerIdentityRegistry;
   IHooksFactoryRevolving hooksFactoryRevolving;
   address hooksTemplate;
   MockERC20 underlying = new MockERC20('Underlying', 'UND', 18);
@@ -42,6 +44,7 @@ contract HooksFactoryRevolvingTest is Test, Assertions {
 
   function setUp() public {
     archController = new WildcatArchController();
+    borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(address(archController));
 
     (address marketTemplate, uint256 marketInitCodeHash) = _storeMarketInitCode();
     hooksFactoryRevolving = new HooksFactoryRevolving(
@@ -49,7 +52,8 @@ contract HooksFactoryRevolvingTest is Test, Assertions {
       sanctionsSentinel,
       address(this),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
     hooksTemplate = LibStoredInitCode.deployInitCode(type(MockHooks).creationCode);
     archController.registerControllerFactory(address(hooksFactoryRevolving));
@@ -81,6 +85,10 @@ contract HooksFactoryRevolvingTest is Test, Assertions {
   function test_nameAndRegistrationWiring() external view {
     assertEq(hooksFactoryRevolving.name(), 'WildcatHooksFactoryRevolving');
     assertEq(hooksFactoryRevolving.archController(), address(archController));
+    assertEq(
+      hooksFactoryRevolving.borrowerIdentityRegistry(),
+      address(borrowerIdentityRegistry)
+    );
     assertTrue(archController.isRegisteredControllerFactory(address(hooksFactoryRevolving)));
     assertTrue(archController.isRegisteredController(address(hooksFactoryRevolving)));
   }
@@ -522,7 +530,8 @@ contract HooksFactoryRevolvingTest is Test, Assertions {
       sanctionsSentinel,
       address(this),
       marketTemplate,
-      uint256(keccak256('stale revolving market init code hash'))
+      uint256(keccak256('stale revolving market init code hash')),
+      address(borrowerIdentityRegistry)
     );
     archController.registerControllerFactory(address(badFactory));
     badFactory.registerWithArchController();

--- a/test/WildcatBorrowerIdentityRegistry.t.sol
+++ b/test/WildcatBorrowerIdentityRegistry.t.sol
@@ -226,7 +226,7 @@ contract WildcatBorrowerIdentityRegistryTest is Test {
     assertEq(registry.accountFactoryOf(account), address(accountFactory));
   }
 
-  function testFuzz_registerBorrowerAccount_AssociationIsImmutable(
+  function testFuzz_registerBorrowerAccount_CannotRegisterSameAccountTwice(
     address replacementPrincipal
   ) external {
     vm.assume(replacementPrincipal != address(0));
@@ -238,6 +238,270 @@ contract WildcatBorrowerIdentityRegistryTest is Test {
     accountFactory.registerAccount(account, replacementPrincipal);
 
     assertEq(registry.principalOf(account), principal);
+  }
+
+  function test_requestBorrowerAccountPrincipalTransfer() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+
+    vm.expectEmit(address(registry));
+    emit IBorrowerIdentityRegistry.BorrowerAccountPrincipalTransferRequested(
+      account,
+      principal,
+      address(0),
+      secondPrincipal
+    );
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+
+    assertEq(registry.principalOf(account), principal);
+    assertEq(registry.pendingPrincipalOf(account), secondPrincipal);
+    assertEq(registry.resolveBorrower(account), principal);
+  }
+
+  function test_requestBorrowerAccountPrincipalTransfer_ReplacesPendingPrincipal() external {
+    address account = accountFactory.deployAccount(principal);
+    address thirdPrincipal = address(0xCAFE);
+    archController.registerBorrower(secondPrincipal);
+    archController.registerBorrower(thirdPrincipal);
+
+    vm.startPrank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+    vm.expectEmit(address(registry));
+    emit IBorrowerIdentityRegistry.BorrowerAccountPrincipalTransferRequested(
+      account,
+      principal,
+      secondPrincipal,
+      thirdPrincipal
+    );
+    registry.requestBorrowerAccountPrincipalTransfer(account, thirdPrincipal);
+    vm.stopPrank();
+
+    assertEq(registry.pendingPrincipalOf(account), thirdPrincipal);
+    vm.prank(secondPrincipal);
+    vm.expectRevert(
+      IBorrowerIdentityRegistry.CallerNotPendingBorrowerAccountPrincipal.selector
+    );
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+  }
+
+  function test_requestBorrowerAccountPrincipalTransfer_Authorization() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotBorrowerAccountPrincipal.selector);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerAccountNotRegistered.selector);
+    registry.requestBorrowerAccountPrincipalTransfer(address(0xBAD), secondPrincipal);
+  }
+
+  function test_requestBorrowerAccountPrincipalTransfer_InvalidTargets() external {
+    address account = accountFactory.deployAccount(principal);
+    vm.startPrank(principal);
+
+    vm.expectRevert(
+      IBorrowerIdentityRegistry.InvalidBorrowerAccountPrincipalTransferTarget.selector
+    );
+    registry.requestBorrowerAccountPrincipalTransfer(account, address(0));
+
+    vm.expectRevert(
+      IBorrowerIdentityRegistry.InvalidBorrowerAccountPrincipalTransferTarget.selector
+    );
+    registry.requestBorrowerAccountPrincipalTransfer(account, principal);
+
+    vm.expectRevert(
+      IBorrowerIdentityRegistry.InvalidBorrowerAccountPrincipalTransferTarget.selector
+    );
+    registry.requestBorrowerAccountPrincipalTransfer(account, account);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerPrincipalNotRegistered.selector);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+    vm.stopPrank();
+  }
+
+  function test_requestBorrowerAccountPrincipalTransfer_RejectsAccountAsPrincipal() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    address secondAccount = accountFactory.deployAccount(secondPrincipal);
+
+    vm.prank(principal);
+    vm.expectRevert(IBorrowerIdentityRegistry.AmbiguousBorrowerIdentity.selector);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondAccount);
+  }
+
+  function test_requestBorrowerAccountPrincipalTransfer_RejectsAmbiguousAccount() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    archController.registerBorrower(account);
+
+    vm.prank(principal);
+    vm.expectRevert(IBorrowerIdentityRegistry.AmbiguousBorrowerIdentity.selector);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+  }
+
+  function test_cancelBorrowerAccountPrincipalTransfer() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+
+    vm.expectEmit(address(registry));
+    emit IBorrowerIdentityRegistry.BorrowerAccountPrincipalTransferCancelled(
+      account,
+      principal,
+      secondPrincipal
+    );
+    vm.prank(principal);
+    registry.cancelBorrowerAccountPrincipalTransfer(account);
+
+    assertEq(registry.principalOf(account), principal);
+    assertEq(registry.pendingPrincipalOf(account), address(0));
+  }
+
+  function test_cancelBorrowerAccountPrincipalTransfer_Authorization() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotBorrowerAccountPrincipal.selector);
+    registry.cancelBorrowerAccountPrincipalTransfer(account);
+
+    vm.prank(principal);
+    registry.cancelBorrowerAccountPrincipalTransfer(account);
+    vm.prank(principal);
+    vm.expectRevert(
+      IBorrowerIdentityRegistry.NoPendingBorrowerAccountPrincipalTransfer.selector
+    );
+    registry.cancelBorrowerAccountPrincipalTransfer(account);
+  }
+
+  function test_acceptBorrowerAccountPrincipalTransfer() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+
+    vm.expectEmit(address(registry));
+    emit IBorrowerIdentityRegistry.BorrowerAccountPrincipalTransferred(
+      account,
+      principal,
+      secondPrincipal
+    );
+    vm.prank(secondPrincipal);
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+
+    assertEq(registry.principalOf(account), secondPrincipal);
+    assertEq(registry.pendingPrincipalOf(account), address(0));
+    assertEq(registry.resolveBorrower(account), secondPrincipal);
+    assertEq(registry.getBorrowerAccountsCount(principal), 0);
+    assertEq(registry.getBorrowerAccountsCount(secondPrincipal), 1);
+    assertEq(registry.getBorrowerAccounts(secondPrincipal)[0], account);
+    assertEq(registry.accountFactoryOf(account), address(accountFactory));
+    assertEq(registry.getBorrowerAccountsForFactory(address(accountFactory))[0], account);
+  }
+
+  function test_acceptBorrowerAccountPrincipalTransfer_UpdatesAuthority() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+    vm.prank(secondPrincipal);
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+
+    vm.prank(principal);
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotBorrowerAccountPrincipal.selector);
+    registry.requestBorrowerAccountPrincipalTransfer(account, principal);
+
+    vm.prank(secondPrincipal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, principal);
+    vm.prank(principal);
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+
+    assertEq(registry.principalOf(account), principal);
+  }
+
+  function test_acceptBorrowerAccountPrincipalTransfer_SurvivesFactoryRemoval() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    registry.removeAccountFactory(address(accountFactory));
+
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+    vm.prank(secondPrincipal);
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+
+    assertEq(registry.resolveBorrower(account), secondPrincipal);
+  }
+
+  function test_acceptBorrowerAccountPrincipalTransfer_AfterCurrentPrincipalRemoval() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    archController.removeBorrower(principal);
+
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+    vm.prank(secondPrincipal);
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+
+    assertEq(registry.resolveBorrower(account), secondPrincipal);
+  }
+
+  function test_acceptBorrowerAccountPrincipalTransfer_RevalidatesRegistration() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+    archController.removeBorrower(secondPrincipal);
+
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerPrincipalNotRegistered.selector);
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+
+    assertEq(registry.principalOf(account), principal);
+    assertEq(registry.pendingPrincipalOf(account), secondPrincipal);
+  }
+
+  function test_acceptBorrowerAccountPrincipalTransfer_RevalidatesAccountIdentity() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(account, secondPrincipal);
+    archController.registerBorrower(account);
+
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IBorrowerIdentityRegistry.AmbiguousBorrowerIdentity.selector);
+    registry.acceptBorrowerAccountPrincipalTransfer(account);
+
+    assertEq(registry.principalOf(account), principal);
+    assertEq(registry.pendingPrincipalOf(account), secondPrincipal);
+  }
+
+  function test_acceptBorrowerAccountPrincipalTransfer_MovesCurrentEnumeration() external {
+    address firstAccount = accountFactory.deployAccount(principal);
+    address secondAccount = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+    vm.prank(principal);
+    registry.requestBorrowerAccountPrincipalTransfer(firstAccount, secondPrincipal);
+    vm.prank(secondPrincipal);
+    registry.acceptBorrowerAccountPrincipalTransfer(firstAccount);
+
+    address[] memory principalAccounts = registry.getBorrowerAccounts(principal);
+    address[] memory secondPrincipalAccounts = registry.getBorrowerAccounts(secondPrincipal);
+    assertEq(principalAccounts.length, 1);
+    assertEq(principalAccounts[0], secondAccount);
+    assertEq(secondPrincipalAccounts.length, 1);
+    assertEq(secondPrincipalAccounts[0], firstAccount);
+
+    address[] memory factoryAccounts = registry.getBorrowerAccountsForFactory(
+      address(accountFactory)
+    );
+    assertEq(factoryAccounts.length, 2);
+    assertEq(factoryAccounts[0], firstAccount);
+    assertEq(factoryAccounts[1], secondAccount);
   }
 
   function test_resolveBorrower_DirectPrincipal() external view {

--- a/test/WildcatBorrowerIdentityRegistry.t.sol
+++ b/test/WildcatBorrowerIdentityRegistry.t.sol
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import 'forge-std/Test.sol';
+import 'src/WildcatArchController.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
+import 'src/interfaces/IBorrowerIdentityRegistry.sol';
+
+contract MockBorrowerAccount {}
+
+contract MockBorrowerAccountFactory {
+  IBorrowerIdentityRegistry public immutable registry;
+
+  constructor(address registry_) {
+    registry = IBorrowerIdentityRegistry(registry_);
+  }
+
+  function deployAccount(address principal) external returns (address account) {
+    account = address(new MockBorrowerAccount());
+    registry.registerBorrowerAccount(account, principal);
+  }
+
+  function registerAccount(address account, address principal) external {
+    registry.registerBorrowerAccount(account, principal);
+  }
+}
+
+contract WildcatBorrowerIdentityRegistryTest is Test {
+  WildcatArchController internal archController;
+  WildcatBorrowerIdentityRegistry internal registry;
+  MockBorrowerAccountFactory internal accountFactory;
+
+  address internal constant principal = address(0xA11CE);
+  address internal constant secondPrincipal = address(0xB0B);
+
+  function setUp() public {
+    archController = new WildcatArchController();
+    registry = new WildcatBorrowerIdentityRegistry(address(archController));
+    accountFactory = new MockBorrowerAccountFactory(address(registry));
+
+    archController.registerBorrower(principal);
+    registry.addAccountFactory(address(accountFactory));
+  }
+
+  function test_constructor() external view {
+    assertEq(registry.archController(), address(archController));
+  }
+
+  function test_constructor_InvalidArchController() external {
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidArchController.selector);
+    new WildcatBorrowerIdentityRegistry(address(0));
+
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidArchController.selector);
+    new WildcatBorrowerIdentityRegistry(address(0xBEEF));
+  }
+
+  function test_addAccountFactory() external {
+    MockBorrowerAccountFactory secondFactory = new MockBorrowerAccountFactory(address(registry));
+
+    vm.expectEmit(address(registry));
+    emit IBorrowerIdentityRegistry.AccountFactoryAdded(address(secondFactory));
+    registry.addAccountFactory(address(secondFactory));
+
+    assertTrue(registry.isAccountFactory(address(secondFactory)));
+    assertEq(registry.getAccountFactoriesCount(), 2);
+    address[] memory factories = registry.getAccountFactories();
+    assertEq(factories[0], address(accountFactory));
+    assertEq(factories[1], address(secondFactory));
+  }
+
+  function test_addAccountFactory_CallerNotArchControllerOwner() external {
+    MockBorrowerAccountFactory secondFactory = new MockBorrowerAccountFactory(address(registry));
+    vm.prank(address(0xBAD));
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotArchControllerOwner.selector);
+    registry.addAccountFactory(address(secondFactory));
+  }
+
+  function test_addAccountFactory_InvalidAccountFactory() external {
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidAccountFactory.selector);
+    registry.addAccountFactory(address(0));
+
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidAccountFactory.selector);
+    registry.addAccountFactory(address(0xBEEF));
+  }
+
+  function test_addAccountFactory_AccountFactoryAlreadyExists() external {
+    vm.expectRevert(IBorrowerIdentityRegistry.AccountFactoryAlreadyExists.selector);
+    registry.addAccountFactory(address(accountFactory));
+  }
+
+  function test_addAccountFactory_FollowsArchControllerOwner() external {
+    address newOwner = address(0xB055);
+    MockBorrowerAccountFactory secondFactory = new MockBorrowerAccountFactory(address(registry));
+    archController.transferOwnership(newOwner);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotArchControllerOwner.selector);
+    registry.addAccountFactory(address(secondFactory));
+
+    vm.prank(newOwner);
+    registry.addAccountFactory(address(secondFactory));
+    assertTrue(registry.isAccountFactory(address(secondFactory)));
+  }
+
+  function test_removeAccountFactory() external {
+    address account = accountFactory.deployAccount(principal);
+
+    vm.expectEmit(address(registry));
+    emit IBorrowerIdentityRegistry.AccountFactoryRemoved(address(accountFactory));
+    registry.removeAccountFactory(address(accountFactory));
+
+    assertFalse(registry.isAccountFactory(address(accountFactory)));
+    assertEq(registry.getAccountFactoriesCount(), 0);
+    assertEq(registry.resolveBorrower(account), principal);
+    assertEq(registry.accountFactoryOf(account), address(accountFactory));
+    assertEq(registry.getBorrowerAccountsForFactoryCount(address(accountFactory)), 1);
+
+    address secondAccount = address(new MockBorrowerAccount());
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotAccountFactory.selector);
+    accountFactory.registerAccount(secondAccount, principal);
+  }
+
+  function test_removeAccountFactory_CallerNotArchControllerOwner() external {
+    vm.prank(address(0xBAD));
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotArchControllerOwner.selector);
+    registry.removeAccountFactory(address(accountFactory));
+  }
+
+  function test_removeAccountFactory_AccountFactoryDoesNotExist() external {
+    MockBorrowerAccountFactory secondFactory = new MockBorrowerAccountFactory(address(registry));
+    vm.expectRevert(IBorrowerIdentityRegistry.AccountFactoryDoesNotExist.selector);
+    registry.removeAccountFactory(address(secondFactory));
+  }
+
+  function test_registerBorrowerAccount() external {
+    vm.recordLogs();
+    address account = accountFactory.deployAccount(principal);
+    Vm.Log[] memory logs = vm.getRecordedLogs();
+
+    assertEq(logs.length, 1);
+    assertEq(logs[0].emitter, address(registry));
+    assertEq(logs[0].topics[0], IBorrowerIdentityRegistry.BorrowerAccountRegistered.selector);
+    assertEq(address(uint160(uint256(logs[0].topics[1]))), account);
+    assertEq(address(uint160(uint256(logs[0].topics[2]))), principal);
+    assertEq(address(uint160(uint256(logs[0].topics[3]))), address(accountFactory));
+
+    assertEq(registry.principalOf(account), principal);
+    assertEq(registry.accountFactoryOf(account), address(accountFactory));
+    assertEq(registry.resolveBorrower(account), principal);
+    assertEq(registry.getBorrowerAccountsCount(principal), 1);
+    assertEq(registry.getBorrowerAccountsForFactoryCount(address(accountFactory)), 1);
+    assertEq(registry.getBorrowerAccounts(principal)[0], account);
+    assertEq(registry.getBorrowerAccountsForFactory(address(accountFactory))[0], account);
+  }
+
+  function test_registerBorrowerAccount_MultipleAccountsForPrincipal() external {
+    address firstAccount = accountFactory.deployAccount(principal);
+    address secondAccount = accountFactory.deployAccount(principal);
+
+    address[] memory accounts = registry.getBorrowerAccounts(principal);
+    assertEq(accounts.length, 2);
+    assertEq(accounts[0], firstAccount);
+    assertEq(accounts[1], secondAccount);
+    assertEq(registry.resolveBorrower(firstAccount), principal);
+    assertEq(registry.resolveBorrower(secondAccount), principal);
+  }
+
+  function test_registerBorrowerAccount_CallerNotAccountFactory() external {
+    address account = address(new MockBorrowerAccount());
+    vm.expectRevert(IBorrowerIdentityRegistry.CallerNotAccountFactory.selector);
+    registry.registerBorrowerAccount(account, principal);
+  }
+
+  function test_registerBorrowerAccount_InvalidBorrowerAccount() external {
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidBorrowerAccount.selector);
+    accountFactory.registerAccount(address(0), principal);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidBorrowerAccount.selector);
+    accountFactory.registerAccount(address(0xBEEF), principal);
+
+    MockBorrowerAccount account = new MockBorrowerAccount();
+    archController.registerBorrower(address(account));
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidBorrowerAccount.selector);
+    accountFactory.registerAccount(address(account), address(account));
+  }
+
+  function test_registerBorrowerAccount_BorrowerPrincipalNotRegistered() external {
+    address account = address(new MockBorrowerAccount());
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerPrincipalNotRegistered.selector);
+    accountFactory.registerAccount(account, secondPrincipal);
+  }
+
+  function test_registerBorrowerAccount_ZeroPrincipalRegisteredOnArchController() external {
+    archController.registerBorrower(address(0));
+    address account = address(new MockBorrowerAccount());
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerPrincipalNotRegistered.selector);
+    accountFactory.registerAccount(account, address(0));
+    assertEq(registry.principalOf(account), address(0));
+  }
+
+  function test_registerBorrowerAccount_AmbiguousAccount() external {
+    address account = address(new MockBorrowerAccount());
+    archController.registerBorrower(account);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.AmbiguousBorrowerIdentity.selector);
+    accountFactory.registerAccount(account, principal);
+  }
+
+  function test_registerBorrowerAccount_AmbiguousPrincipal() external {
+    address principalAccount = accountFactory.deployAccount(principal);
+    archController.registerBorrower(principalAccount);
+    address account = address(new MockBorrowerAccount());
+
+    vm.expectRevert(IBorrowerIdentityRegistry.AmbiguousBorrowerIdentity.selector);
+    accountFactory.registerAccount(account, principalAccount);
+  }
+
+  function test_registerBorrowerAccount_BorrowerAccountAlreadyRegistered() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(secondPrincipal);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerAccountAlreadyRegistered.selector);
+    accountFactory.registerAccount(account, secondPrincipal);
+
+    assertEq(registry.principalOf(account), principal);
+    assertEq(registry.accountFactoryOf(account), address(accountFactory));
+  }
+
+  function testFuzz_registerBorrowerAccount_AssociationIsImmutable(
+    address replacementPrincipal
+  ) external {
+    vm.assume(replacementPrincipal != address(0));
+    vm.assume(replacementPrincipal != principal);
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(replacementPrincipal);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerAccountAlreadyRegistered.selector);
+    accountFactory.registerAccount(account, replacementPrincipal);
+
+    assertEq(registry.principalOf(account), principal);
+  }
+
+  function test_resolveBorrower_DirectPrincipal() external view {
+    assertEq(registry.resolveBorrower(principal), principal);
+  }
+
+  function test_resolveBorrower_BorrowerIdentityNotFound() external {
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerIdentityNotFound.selector);
+    registry.resolveBorrower(address(0));
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerIdentityNotFound.selector);
+    registry.resolveBorrower(address(0xBEEF));
+  }
+
+  function test_resolveBorrower_BorrowerPrincipalNotRegistered() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.removeBorrower(principal);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerPrincipalNotRegistered.selector);
+    registry.resolveBorrower(account);
+  }
+
+  function test_resolveBorrower_AmbiguousBorrowerIdentity() external {
+    address account = accountFactory.deployAccount(principal);
+    archController.registerBorrower(account);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.AmbiguousBorrowerIdentity.selector);
+    registry.resolveBorrower(account);
+  }
+
+  function test_getAccountFactories_Pagination() external {
+    MockBorrowerAccountFactory secondFactory = new MockBorrowerAccountFactory(address(registry));
+    registry.addAccountFactory(address(secondFactory));
+
+    address[] memory factories = registry.getAccountFactories(1, 10);
+    assertEq(factories.length, 1);
+    assertEq(factories[0], address(secondFactory));
+    assertEq(registry.getAccountFactories(2, 2).length, 0);
+    assertEq(registry.getAccountFactories(10, 20).length, 0);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidPaginationRange.selector);
+    registry.getAccountFactories(2, 1);
+  }
+
+  function test_getBorrowerAccounts_Pagination() external {
+    address firstAccount = accountFactory.deployAccount(principal);
+    address secondAccount = accountFactory.deployAccount(principal);
+
+    address[] memory accounts = registry.getBorrowerAccounts(principal, 1, 10);
+    assertEq(accounts.length, 1);
+    assertEq(accounts[0], secondAccount);
+    assertEq(registry.getBorrowerAccounts(principal, 2, 2).length, 0);
+    assertEq(registry.getBorrowerAccounts(principal, 10, 20).length, 0);
+
+    accounts = registry.getBorrowerAccountsForFactory(address(accountFactory), 0, 1);
+    assertEq(accounts.length, 1);
+    assertEq(accounts[0], firstAccount);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidPaginationRange.selector);
+    registry.getBorrowerAccounts(principal, 2, 1);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.InvalidPaginationRange.selector);
+    registry.getBorrowerAccountsForFactory(address(accountFactory), 2, 1);
+  }
+}

--- a/test/helpers/ExpectedStateTracker.sol
+++ b/test/helpers/ExpectedStateTracker.sol
@@ -69,7 +69,7 @@ contract ExpectedStateTracker is Test, IMarketEventsAndErrors {
               abi.encodePacked(
                 bytes1(0xff),
                 parameters.sentinel,
-                keccak256(abi.encode(parameters.borrower, accountAddress, asset)),
+                keccak256(abi.encode(market.borrowerPrincipal(), accountAddress, asset)),
                 WildcatSanctionsEscrowInitcodeHash
               )
             )
@@ -434,7 +434,10 @@ contract ExpectedStateTracker is Test, IMarketEventsAndErrors {
 
     uint128 normalizedAmountWithdrawn = newTotalWithdrawn - status.normalizedAmountWithdrawn;
     MarketAccount storage account = _getAccount(accountAddress);
-    bool isSanctioned = sanctionsSentinel.isSanctioned(borrower, accountAddress);
+    bool isSanctioned = sanctionsSentinel.isSanctioned(
+      market.borrowerPrincipal(),
+      accountAddress
+    );
     _trackExecuteWithdrawal(state, expiry, accountAddress, normalizedAmountWithdrawn, isSanctioned);
   }
 

--- a/test/integration/MarketConfigMatrix.sol
+++ b/test/integration/MarketConfigMatrix.sol
@@ -251,7 +251,8 @@ contract MarketConfigMatrix is BaseMarketTest {
       address(sanctionsSentinel),
       address(wrapperFactory),
       revolvingMarketInitCodeStorage,
-      revolvingMarketInitCodeHash
+      revolvingMarketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
     archController.registerControllerFactory(address(revolvingFactory));
     revolvingFactory.registerWithArchController();

--- a/test/invariants/CAF12MarketInvariants.t.sol
+++ b/test/invariants/CAF12MarketInvariants.t.sol
@@ -7,6 +7,7 @@ import { MockERC20 } from 'solmate/test/utils/mocks/MockERC20.sol';
 import { HooksFactory } from 'src/HooksFactory.sol';
 import { HooksFactoryRevolving } from 'src/HooksFactoryRevolving.sol';
 import { WildcatArchController } from 'src/WildcatArchController.sol';
+import { WildcatBorrowerIdentityRegistry } from 'src/WildcatBorrowerIdentityRegistry.sol';
 import { LibStoredInitCode } from 'src/libraries/LibStoredInitCode.sol';
 import { MathUtils, RAY } from 'src/libraries/MathUtils.sol';
 import { MarketState } from 'src/libraries/MarketState.sol';
@@ -52,6 +53,9 @@ abstract contract CAF12InvariantDeployer is ForgeTest {
     deployMockChainalysis();
 
     WildcatArchController archController = new WildcatArchController();
+    WildcatBorrowerIdentityRegistry borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(
+      address(archController)
+    );
     sanctionsSentinel = new MockSanctionsSentinel(address(archController));
     (address marketTemplate, uint256 marketInitCodeHash) = _storeMarketInitCode(false);
 
@@ -60,7 +64,8 @@ abstract contract CAF12InvariantDeployer is ForgeTest {
       address(sanctionsSentinel),
       address(this),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
     archController.registerControllerFactory(address(hooksFactory));
     hooksFactory.registerWithArchController();
@@ -105,6 +110,9 @@ abstract contract CAF12InvariantDeployer is ForgeTest {
     deployMockChainalysis();
 
     WildcatArchController archController = new WildcatArchController();
+    WildcatBorrowerIdentityRegistry borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(
+      address(archController)
+    );
     MockSanctionsSentinel sanctionsSentinel = new MockSanctionsSentinel(address(archController));
     (address marketTemplate, uint256 marketInitCodeHash) = _storeMarketInitCode(true);
 
@@ -113,7 +121,8 @@ abstract contract CAF12InvariantDeployer is ForgeTest {
       address(sanctionsSentinel),
       address(this),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
     archController.registerControllerFactory(address(hooksFactory));
     hooksFactory.registerWithArchController();

--- a/test/lens/MarketLens.t.sol
+++ b/test/lens/MarketLens.t.sol
@@ -381,6 +381,7 @@ contract MarketDataTest is BaseMarketTest {
     assertEq(pendingData.market.borrower, borrower, 'pending market borrower');
     assertEq(pendingData.borrowerPrincipal, borrower, 'pending market principal');
     assertEq(pendingData.pendingBorrower, nextBorrower, 'pending borrower');
+    assertEq(pendingData.pendingBorrowerPrincipal, borrower, 'pending borrower principal');
     assertEq(
       pendingData.borrowerIdentityRegistry,
       address(borrowerIdentityRegistry),
@@ -396,11 +397,57 @@ contract MarketDataTest is BaseMarketTest {
     assertEq(acceptedData.borrowerPrincipal, borrower, 'accepted market principal');
     assertEq(acceptedData.pendingBorrower, address(0), 'accepted pending borrower');
     assertEq(
+      acceptedData.pendingBorrowerPrincipal,
+      address(0),
+      'accepted pending borrower principal'
+    );
+    assertEq(
       acceptedData.borrowerIdentityRegistry,
       address(borrowerIdentityRegistry),
       'accepted identity registry'
     );
     assertEq(acceptedData.market.hooks.borrower, borrower, 'accepted hook administrator');
+  }
+
+  function test_getMarketDataV2_tracksSameAccountPrincipalMigration() external {
+    MarketLensBorrowerAccountFactory accountFactory = new MarketLensBorrowerAccountFactory(
+      address(borrowerIdentityRegistry)
+    );
+    borrowerIdentityRegistry.addAccountFactory(address(accountFactory));
+    address account = accountFactory.deployAccount(borrower);
+    address newPrincipal = address(0xB0B);
+    archController.registerBorrower(newPrincipal);
+
+    vm.prank(borrower);
+    market.requestBorrowerTransfer(account);
+    vm.prank(account);
+    market.acceptBorrowerTransfer();
+
+    vm.prank(borrower);
+    borrowerIdentityRegistry.requestBorrowerAccountPrincipalTransfer(account, newPrincipal);
+    vm.prank(newPrincipal);
+    borrowerIdentityRegistry.acceptBorrowerAccountPrincipalTransfer(account);
+    vm.prank(account);
+    market.requestBorrowerTransfer(account);
+
+    MarketDataV2_5 memory pendingData = lens.getMarketDataV2(address(market));
+    assertEq(pendingData.market.borrower, account, 'pending market borrower');
+    assertEq(pendingData.borrowerPrincipal, borrower, 'pending market principal');
+    assertEq(pendingData.pendingBorrower, account, 'pending borrower');
+    assertEq(pendingData.pendingBorrowerPrincipal, newPrincipal, 'pending borrower principal');
+
+    vm.prank(account);
+    market.acceptBorrowerTransfer();
+
+    MarketDataV2_5 memory acceptedData = lens.getMarketDataV2(address(market));
+    assertEq(acceptedData.market.borrower, account, 'accepted market borrower');
+    assertEq(acceptedData.borrowerPrincipal, newPrincipal, 'accepted market principal');
+    assertEq(acceptedData.pendingBorrower, address(0), 'accepted pending borrower');
+    assertEq(
+      acceptedData.pendingBorrowerPrincipal,
+      address(0),
+      'accepted pending borrower principal'
+    );
   }
 
   function test_coreDelegation_forAccountAndWithdrawalReads() external {

--- a/test/lens/MarketLens.t.sol
+++ b/test/lens/MarketLens.t.sol
@@ -19,6 +19,7 @@ import '../helpers/fuzz/MarketConfigFuzzInputs.sol';
 import 'src/lens/MarketLens.sol';
 import { PeriodicTermHooks } from 'src/access/PeriodicTermHooks.sol';
 import 'src/IHooksFactory.sol';
+import 'src/interfaces/IBorrowerIdentityRegistry.sol';
 
 enum FuzzConditions {
   Default,
@@ -59,6 +60,21 @@ contract HooksInstanceDataHarness {
     IHooksFactory factory
   ) external view returns (HooksInstanceData memory data) {
     data.fill(hooksAddress, factory);
+  }
+}
+
+contract MarketLensBorrowerAccount {}
+
+contract MarketLensBorrowerAccountFactory {
+  IBorrowerIdentityRegistry public immutable registry;
+
+  constructor(address registry_) {
+    registry = IBorrowerIdentityRegistry(registry_);
+  }
+
+  function deployAccount(address principal) external returns (address account) {
+    account = address(new MarketLensBorrowerAccount());
+    registry.registerBorrowerAccount(account, principal);
   }
 }
 
@@ -349,6 +365,42 @@ contract MarketDataTest is BaseMarketTest {
     assertEq(data.market.originalAnnualInterestBips, 0, 'originalAnnualInterestBips');
     assertEq(data.market.originalReserveRatioBips, 0, 'originalReserveRatioBips');
     assertEq(data.market.temporaryReserveRatioExpiry, 0, 'temporaryReserveRatioExpiry');
+  }
+
+  function test_getMarketDataV2_tracksBorrowerTransferWithoutRelabelingHooks() external {
+    MarketLensBorrowerAccountFactory accountFactory = new MarketLensBorrowerAccountFactory(
+      address(borrowerIdentityRegistry)
+    );
+    borrowerIdentityRegistry.addAccountFactory(address(accountFactory));
+    address nextBorrower = accountFactory.deployAccount(borrower);
+
+    vm.prank(borrower);
+    market.requestBorrowerTransfer(nextBorrower);
+
+    MarketDataV2_5 memory pendingData = lens.getMarketDataV2(address(market));
+    assertEq(pendingData.market.borrower, borrower, 'pending market borrower');
+    assertEq(pendingData.borrowerPrincipal, borrower, 'pending market principal');
+    assertEq(pendingData.pendingBorrower, nextBorrower, 'pending borrower');
+    assertEq(
+      pendingData.borrowerIdentityRegistry,
+      address(borrowerIdentityRegistry),
+      'identity registry'
+    );
+    assertEq(pendingData.market.hooks.borrower, borrower, 'pending hook administrator');
+
+    vm.prank(nextBorrower);
+    market.acceptBorrowerTransfer();
+
+    MarketDataV2_5 memory acceptedData = lens.getMarketDataV2(address(market));
+    assertEq(acceptedData.market.borrower, nextBorrower, 'accepted market borrower');
+    assertEq(acceptedData.borrowerPrincipal, borrower, 'accepted market principal');
+    assertEq(acceptedData.pendingBorrower, address(0), 'accepted pending borrower');
+    assertEq(
+      acceptedData.borrowerIdentityRegistry,
+      address(borrowerIdentityRegistry),
+      'accepted identity registry'
+    );
+    assertEq(acceptedData.market.hooks.borrower, borrower, 'accepted hook administrator');
   }
 
   function test_coreDelegation_forAccountAndWithdrawalReads() external {

--- a/test/lens/MarketLensMultiFactory.t.sol
+++ b/test/lens/MarketLensMultiFactory.t.sol
@@ -76,7 +76,8 @@ contract MarketLensMultiFactoryTest is BaseMarketTest {
       address(sanctionsSentinel),
       address(this),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
 
     archController.registerControllerFactory(address(hooksFactoryRevolving));
@@ -584,7 +585,8 @@ contract MarketLensMultiFactoryTest is BaseMarketTest {
       address(sanctionsSentinel),
       address(this),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
     MarketLensAggregator aggregator = new MarketLensAggregator(
       address(archController),

--- a/test/market/WildcatMarketBase.t.sol
+++ b/test/market/WildcatMarketBase.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.20;
 import '../BaseMarketTest.sol';
 import '../shared/mocks/MockHooks.sol';
 import 'src/ReentrancyGuard.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
 
 contract ProtocolFeeReadOnDepositHooks is MockHooks {
   bool public protocolFeeReadSucceeded;
@@ -57,41 +58,62 @@ contract MockMarketParametersFactory {
 }
 
 contract WildcatMarketBaseTest is BaseMarketTest {
+  function _getConstructorParameters(
+    address operationalBorrower,
+    address principal,
+    address identityRegistry,
+    HooksConfig hooksConfig
+  ) internal view returns (MarketParameters memory) {
+    return
+      MarketParameters({
+        asset: address(asset),
+        decimals: 18,
+        packedNameWord0: bytes32(0),
+        packedNameWord1: bytes32(0),
+        packedSymbolWord0: bytes32(0),
+        packedSymbolWord1: bytes32(0),
+        borrower: operationalBorrower,
+        feeRecipient: feeRecipient,
+        sentinel: address(sanctionsSentinel),
+        wrapperFactory: address(wrapperFactory),
+        maxTotalSupply: uint128(DefaultMaximumSupply),
+        protocolFeeBips: DefaultProtocolFeeBips,
+        annualInterestBips: DefaultInterest,
+        delinquencyFeeBips: DefaultDelinquencyFee,
+        withdrawalBatchDuration: DefaultWithdrawalBatchDuration,
+        reserveRatioBips: DefaultReserveRatio,
+        delinquencyGracePeriod: DefaultGracePeriod,
+        archController: address(archController),
+        sphereXEngine: address(0),
+        hooks: hooksConfig,
+        borrowerPrincipal: principal,
+        borrowerIdentityRegistry: identityRegistry
+      });
+  }
+
   function test_constructorSupportsDistinctBorrowerAndPrincipal() external {
     address operationalBorrower = address(0xD00D);
     address principal = address(0xA11CE);
     HooksConfig hooksConfig = HooksConfig.wrap((uint256(0xBEEF) << 96) | 0xA5);
     archController.registerBorrower(principal);
 
-    MarketParameters memory constructorParameters = MarketParameters({
-      asset: address(asset),
-      decimals: 18,
-      packedNameWord0: bytes32(0),
-      packedNameWord1: bytes32(0),
-      packedSymbolWord0: bytes32(0),
-      packedSymbolWord1: bytes32(0),
-      borrower: operationalBorrower,
-      feeRecipient: feeRecipient,
-      sentinel: address(sanctionsSentinel),
-      wrapperFactory: address(wrapperFactory),
-      maxTotalSupply: uint128(DefaultMaximumSupply),
-      protocolFeeBips: DefaultProtocolFeeBips,
-      annualInterestBips: DefaultInterest,
-      delinquencyFeeBips: DefaultDelinquencyFee,
-      withdrawalBatchDuration: DefaultWithdrawalBatchDuration,
-      reserveRatioBips: DefaultReserveRatio,
-      delinquencyGracePeriod: DefaultGracePeriod,
-      archController: address(archController),
-      sphereXEngine: address(0),
-      hooks: hooksConfig,
-      borrowerPrincipal: principal
-    });
+    MarketParameters memory constructorParameters = _getConstructorParameters(
+      operationalBorrower,
+      principal,
+      address(borrowerIdentityRegistry),
+      hooksConfig
+    );
 
     MockMarketParametersFactory parameterFactory = new MockMarketParametersFactory();
     WildcatMarket distinctIdentityMarket = parameterFactory.deployMarket(constructorParameters);
 
     assertEq(distinctIdentityMarket.borrower(), operationalBorrower, 'borrower');
     assertEq(distinctIdentityMarket.borrowerPrincipal(), principal, 'borrowerPrincipal');
+    assertEq(
+      distinctIdentityMarket.borrowerIdentityRegistry(),
+      address(borrowerIdentityRegistry),
+      'borrowerIdentityRegistry'
+    );
     assertEq(distinctIdentityMarket.factory(), address(parameterFactory), 'factory');
     assertFalse(archController.isRegisteredBorrower(operationalBorrower));
     assertTrue(archController.isRegisteredBorrower(principal));
@@ -100,17 +122,61 @@ contract WildcatMarketBaseTest is BaseMarketTest {
       abi.encodeCall(MockMarketParametersFactory.getMarketParameters, ())
     );
     assertTrue(success);
-    assertEq(encodedParameters.length, 0x2a0, 'encoded parameters length');
+    assertEq(encodedParameters.length, 0x2c0, 'encoded parameters length');
 
     uint256 encodedHooks;
     address encodedPrincipal;
+    address encodedIdentityRegistry;
     assembly {
-      // `hooks` stays at word 19; `borrowerPrincipal` is appended at word 20.
+      // The original fields end at `hooks`; identity fields follow them.
       encodedHooks := mload(add(encodedParameters, 0x280))
       encodedPrincipal := mload(add(encodedParameters, 0x2a0))
+      encodedIdentityRegistry := mload(add(encodedParameters, 0x2c0))
     }
     assertEq(encodedHooks, HooksConfig.unwrap(hooksConfig), 'hooks word');
     assertEq(encodedPrincipal, principal, 'borrowerPrincipal word');
+    assertEq(
+      encodedIdentityRegistry,
+      address(borrowerIdentityRegistry),
+      'borrowerIdentityRegistry word'
+    );
+  }
+
+  function test_constructorRejectsInvalidBorrowerIdentityRegistry() external {
+    address principal = address(0xA11CE);
+    archController.registerBorrower(principal);
+    MarketParameters memory constructorParameters = _getConstructorParameters(
+      address(0xD00D),
+      principal,
+      address(0),
+      EmptyHooksConfig
+    );
+    MockMarketParametersFactory parameterFactory = new MockMarketParametersFactory();
+
+    vm.expectRevert(IMarketEventsAndErrors.InvalidBorrowerIdentityRegistry.selector);
+    parameterFactory.deployMarket(constructorParameters);
+
+    WildcatArchController otherArchController = new WildcatArchController();
+    WildcatBorrowerIdentityRegistry otherRegistry = new WildcatBorrowerIdentityRegistry(
+      address(otherArchController)
+    );
+    constructorParameters.borrowerIdentityRegistry = address(otherRegistry);
+
+    vm.expectRevert(IMarketEventsAndErrors.InvalidBorrowerIdentityRegistry.selector);
+    parameterFactory.deployMarket(constructorParameters);
+  }
+
+  function test_constructorRejectsUnregisteredBorrowerPrincipal() external {
+    MarketParameters memory constructorParameters = _getConstructorParameters(
+      address(0xD00D),
+      address(0xA11CE),
+      address(borrowerIdentityRegistry),
+      EmptyHooksConfig
+    );
+    MockMarketParametersFactory parameterFactory = new MockMarketParametersFactory();
+
+    vm.expectRevert(IMarketEventsAndErrors.BorrowerPrincipalNotRegistered.selector);
+    parameterFactory.deployMarket(constructorParameters);
   }
 
   // ===================================================================== //

--- a/test/market/WildcatMarketBase.t.sol
+++ b/test/market/WildcatMarketBase.t.sol
@@ -41,7 +41,78 @@ contract ProtocolFeeReadOnDepositHooks is MockHooks {
   }
 }
 
+contract MockMarketParametersFactory {
+  MarketParameters internal _parameters;
+
+  function deployMarket(
+    MarketParameters memory parameters
+  ) external returns (WildcatMarket market) {
+    _parameters = parameters;
+    market = new WildcatMarket();
+  }
+
+  function getMarketParameters() external view returns (MarketParameters memory) {
+    return _parameters;
+  }
+}
+
 contract WildcatMarketBaseTest is BaseMarketTest {
+  function test_constructorSupportsDistinctBorrowerAndPrincipal() external {
+    address operationalBorrower = address(0xD00D);
+    address principal = address(0xA11CE);
+    HooksConfig hooksConfig = HooksConfig.wrap((uint256(0xBEEF) << 96) | 0xA5);
+    archController.registerBorrower(principal);
+
+    MarketParameters memory constructorParameters = MarketParameters({
+      asset: address(asset),
+      decimals: 18,
+      packedNameWord0: bytes32(0),
+      packedNameWord1: bytes32(0),
+      packedSymbolWord0: bytes32(0),
+      packedSymbolWord1: bytes32(0),
+      borrower: operationalBorrower,
+      feeRecipient: feeRecipient,
+      sentinel: address(sanctionsSentinel),
+      wrapperFactory: address(wrapperFactory),
+      maxTotalSupply: uint128(DefaultMaximumSupply),
+      protocolFeeBips: DefaultProtocolFeeBips,
+      annualInterestBips: DefaultInterest,
+      delinquencyFeeBips: DefaultDelinquencyFee,
+      withdrawalBatchDuration: DefaultWithdrawalBatchDuration,
+      reserveRatioBips: DefaultReserveRatio,
+      delinquencyGracePeriod: DefaultGracePeriod,
+      archController: address(archController),
+      sphereXEngine: address(0),
+      hooks: hooksConfig,
+      borrowerPrincipal: principal
+    });
+
+    MockMarketParametersFactory parameterFactory = new MockMarketParametersFactory();
+    WildcatMarket distinctIdentityMarket = parameterFactory.deployMarket(constructorParameters);
+
+    assertEq(distinctIdentityMarket.borrower(), operationalBorrower, 'borrower');
+    assertEq(distinctIdentityMarket.borrowerPrincipal(), principal, 'borrowerPrincipal');
+    assertEq(distinctIdentityMarket.factory(), address(parameterFactory), 'factory');
+    assertFalse(archController.isRegisteredBorrower(operationalBorrower));
+    assertTrue(archController.isRegisteredBorrower(principal));
+
+    (bool success, bytes memory encodedParameters) = address(parameterFactory).staticcall(
+      abi.encodeCall(MockMarketParametersFactory.getMarketParameters, ())
+    );
+    assertTrue(success);
+    assertEq(encodedParameters.length, 0x2a0, 'encoded parameters length');
+
+    uint256 encodedHooks;
+    address encodedPrincipal;
+    assembly {
+      // `hooks` stays at word 19; `borrowerPrincipal` is appended at word 20.
+      encodedHooks := mload(add(encodedParameters, 0x280))
+      encodedPrincipal := mload(add(encodedParameters, 0x2a0))
+    }
+    assertEq(encodedHooks, HooksConfig.unwrap(hooksConfig), 'hooks word');
+    assertEq(encodedPrincipal, principal, 'borrowerPrincipal word');
+  }
+
   // ===================================================================== //
   //                          coverageLiquidity()                          //
   // ===================================================================== //

--- a/test/market/WildcatMarketBase.t.sol
+++ b/test/market/WildcatMarketBase.t.sol
@@ -166,6 +166,21 @@ contract WildcatMarketBaseTest is BaseMarketTest {
     parameterFactory.deployMarket(constructorParameters);
   }
 
+  function test_constructorRejectsZeroOperationalBorrower() external {
+    address principal = address(0xA11CE);
+    archController.registerBorrower(principal);
+    MarketParameters memory constructorParameters = _getConstructorParameters(
+      address(0),
+      principal,
+      address(borrowerIdentityRegistry),
+      EmptyHooksConfig
+    );
+    MockMarketParametersFactory parameterFactory = new MockMarketParametersFactory();
+
+    vm.expectRevert(IMarketEventsAndErrors.InvalidBorrower.selector);
+    parameterFactory.deployMarket(constructorParameters);
+  }
+
   function test_constructorRejectsUnregisteredBorrowerPrincipal() external {
     MarketParameters memory constructorParameters = _getConstructorParameters(
       address(0xD00D),
@@ -174,6 +189,12 @@ contract WildcatMarketBaseTest is BaseMarketTest {
       EmptyHooksConfig
     );
     MockMarketParametersFactory parameterFactory = new MockMarketParametersFactory();
+
+    vm.expectRevert(IMarketEventsAndErrors.BorrowerPrincipalNotRegistered.selector);
+    parameterFactory.deployMarket(constructorParameters);
+
+    archController.registerBorrower(address(0));
+    constructorParameters.borrowerPrincipal = address(0);
 
     vm.expectRevert(IMarketEventsAndErrors.BorrowerPrincipalNotRegistered.selector);
     parameterFactory.deployMarket(constructorParameters);

--- a/test/market/WildcatMarketBorrowerTransfer.t.sol
+++ b/test/market/WildcatMarketBorrowerTransfer.t.sol
@@ -61,6 +61,18 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
     _acceptTransfer(newBorrower);
   }
 
+  function _transferAccountPrincipal(
+    address account,
+    address currentPrincipal,
+    address newPrincipal
+  ) internal {
+    _registerPrincipal(newPrincipal);
+    vm.prank(currentPrincipal);
+    borrowerIdentityRegistry.requestBorrowerAccountPrincipalTransfer(account, newPrincipal);
+    vm.prank(newPrincipal);
+    borrowerIdentityRegistry.acceptBorrowerAccountPrincipalTransfer(account);
+  }
+
   function _clearSanction(address account) internal {
     MockChainalysis(sanctionsSentinel.chainalysisSanctionsList()).unsanction(account);
   }
@@ -111,6 +123,7 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
       address(0),
       secondPrincipal,
       borrower,
+      address(0),
       secondPrincipal
     );
     _requestTransfer(borrower, secondPrincipal);
@@ -118,6 +131,7 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
     assertEq(market.borrower(), borrower);
     assertEq(market.borrowerPrincipal(), borrower);
     assertEq(market.pendingBorrower(), secondPrincipal);
+    assertEq(market.pendingBorrowerPrincipal(), secondPrincipal);
     assertEq(_marketStateHash(), stateHash, 'sequential market state changed');
 
     vm.prank(secondPrincipal);
@@ -136,11 +150,13 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
       secondPrincipal,
       thirdPrincipal,
       borrower,
+      secondPrincipal,
       thirdPrincipal
     );
     _requestTransfer(borrower, thirdPrincipal);
 
     assertEq(market.pendingBorrower(), thirdPrincipal);
+    assertEq(market.pendingBorrowerPrincipal(), thirdPrincipal);
     vm.prank(secondPrincipal);
     vm.expectRevert(IMarketEventsAndErrors.NotPendingBorrower.selector);
     market.acceptBorrowerTransfer();
@@ -151,11 +167,12 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
     _requestTransfer(borrower, secondPrincipal);
 
     vm.expectEmit(address(market));
-    emit BorrowerTransferCancelled(borrower, secondPrincipal, borrower);
+    emit BorrowerTransferCancelled(borrower, secondPrincipal, borrower, secondPrincipal);
     vm.prank(borrower);
     market.cancelBorrowerTransfer();
 
     assertEq(market.pendingBorrower(), address(0));
+    assertEq(market.pendingBorrowerPrincipal(), address(0));
     vm.prank(secondPrincipal);
     vm.expectRevert(IMarketEventsAndErrors.NotPendingBorrower.selector);
     market.acceptBorrowerTransfer();
@@ -170,6 +187,7 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
     market.cancelBorrowerTransfer();
 
     assertEq(market.pendingBorrower(), address(0));
+    assertEq(market.pendingBorrowerPrincipal(), address(0));
   }
 
   function test_cancelBorrowerTransfer_NoPendingTransfer() external {
@@ -219,6 +237,7 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
     assertEq(market.borrower(), secondPrincipal);
     assertEq(market.borrowerPrincipal(), secondPrincipal);
     assertEq(market.pendingBorrower(), address(0));
+    assertEq(market.pendingBorrowerPrincipal(), address(0));
     assertEq(_marketStateHash(), stateHash, 'sequential market state changed');
 
     _registerPrincipal(thirdPrincipal);
@@ -251,6 +270,89 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
 
     assertEq(market.borrower(), secondAccount);
     assertEq(market.borrowerPrincipal(), borrower);
+  }
+
+  function test_acceptBorrowerTransfer_SameAccountPrincipalMigration() external {
+    address account = _deployAccount(borrower);
+    _transferBorrower(borrower, account);
+    bytes32 stateHash = _marketStateHash();
+
+    _transferAccountPrincipal(account, borrower, secondPrincipal);
+
+    assertEq(market.borrower(), account);
+    assertEq(market.borrowerPrincipal(), borrower);
+
+    vm.expectEmit(address(market));
+    emit BorrowerTransferRequested(
+      account,
+      address(0),
+      account,
+      borrower,
+      address(0),
+      secondPrincipal
+    );
+    _requestTransfer(account, account);
+
+    assertEq(market.pendingBorrower(), account);
+    assertEq(market.pendingBorrowerPrincipal(), secondPrincipal);
+    vm.expectEmit(address(market));
+    emit BorrowerTransferred(account, account, borrower, secondPrincipal);
+    _acceptTransfer(account);
+
+    assertEq(market.borrower(), account);
+    assertEq(market.borrowerPrincipal(), secondPrincipal);
+    assertEq(market.pendingBorrower(), address(0));
+    assertEq(market.pendingBorrowerPrincipal(), address(0));
+    assertEq(_marketStateHash(), stateHash, 'sequential market state changed');
+  }
+
+  function test_acceptBorrowerTransfer_BindsPendingAccountPrincipal() external {
+    address account = _deployAccount(borrower);
+    _transferBorrower(borrower, account);
+    _transferAccountPrincipal(account, borrower, secondPrincipal);
+    _requestTransfer(account, account);
+
+    _transferAccountPrincipal(account, secondPrincipal, thirdPrincipal);
+
+    vm.prank(account);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IMarketEventsAndErrors.PendingBorrowerPrincipalChanged.selector,
+        secondPrincipal,
+        thirdPrincipal
+      )
+    );
+    market.acceptBorrowerTransfer();
+
+    assertEq(market.borrower(), account);
+    assertEq(market.borrowerPrincipal(), borrower);
+    assertEq(market.pendingBorrower(), account);
+    assertEq(market.pendingBorrowerPrincipal(), secondPrincipal);
+
+    vm.startPrank(account);
+    market.cancelBorrowerTransfer();
+    market.requestBorrowerTransfer(account);
+    market.acceptBorrowerTransfer();
+    vm.stopPrank();
+
+    assertEq(market.borrower(), account);
+    assertEq(market.borrowerPrincipal(), thirdPrincipal);
+  }
+
+  function test_requestBorrowerTransfer_SameAccountRejectsSanctionedPreviousPrincipal() external {
+    address account = _deployAccount(borrower);
+    _transferBorrower(borrower, account);
+    _transferAccountPrincipal(account, borrower, secondPrincipal);
+    sanctionsSentinel.sanction(borrower);
+
+    vm.prank(account);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IMarketEventsAndErrors.BorrowerTransferWhileSanctioned.selector,
+        borrower
+      )
+    );
+    market.requestBorrowerTransfer(account);
   }
 
   function test_acceptBorrowerTransfer_AccountToDirectPrincipal() external {

--- a/test/market/WildcatMarketBorrowerTransfer.t.sol
+++ b/test/market/WildcatMarketBorrowerTransfer.t.sol
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.20;
+
+import '../BaseMarketTest.sol';
+import 'src/interfaces/IBorrowerIdentityRegistry.sol';
+
+contract BorrowerTransferTestAccount {}
+
+contract BorrowerTransferTestAccountFactory {
+  IBorrowerIdentityRegistry public immutable registry;
+
+  constructor(address registry_) {
+    registry = IBorrowerIdentityRegistry(registry_);
+  }
+
+  function deployAccount(address principal) external returns (address account) {
+    account = address(new BorrowerTransferTestAccount());
+    registry.registerBorrowerAccount(account, principal);
+  }
+}
+
+contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
+  BorrowerTransferTestAccountFactory internal accountFactory;
+
+  address internal constant secondPrincipal = address(0xB0B);
+  address internal constant thirdPrincipal = address(0xCAFE);
+
+  function setUp() public override {
+    super.setUp();
+    accountFactory = new BorrowerTransferTestAccountFactory(address(borrowerIdentityRegistry));
+    borrowerIdentityRegistry.addAccountFactory(address(accountFactory));
+  }
+
+  function _registerPrincipal(address principal) internal {
+    if (!archController.isRegisteredBorrower(principal)) {
+      archController.registerBorrower(principal);
+    }
+  }
+
+  function _deployAccount(address principal) internal returns (address) {
+    _registerPrincipal(principal);
+    return accountFactory.deployAccount(principal);
+  }
+
+  function _requestTransfer(address currentBorrower, address newBorrower) internal {
+    vm.prank(currentBorrower);
+    market.requestBorrowerTransfer(newBorrower);
+  }
+
+  function _acceptTransfer(address newBorrower) internal {
+    vm.prank(newBorrower);
+    market.acceptBorrowerTransfer();
+  }
+
+  function _marketStateHash() internal view returns (bytes32 result) {
+    bytes32[7] memory slots;
+    for (uint256 i = 0; i < slots.length; i++) {
+      slots[i] = vm.load(address(market), bytes32(i));
+    }
+    result = keccak256(abi.encode(slots));
+  }
+
+  function _expectTransfer(
+    address previousBorrower,
+    address newBorrower,
+    address previousPrincipal,
+    address newPrincipal
+  ) internal {
+    vm.expectEmit(address(market));
+    emit BorrowerTransferred(previousBorrower, newBorrower, previousPrincipal, newPrincipal);
+    _acceptTransfer(newBorrower);
+  }
+
+  function test_requestBorrowerTransfer() external {
+    _registerPrincipal(secondPrincipal);
+    bytes32 stateHash = _marketStateHash();
+
+    vm.expectEmit(address(market));
+    emit BorrowerTransferRequested(
+      borrower,
+      address(0),
+      secondPrincipal,
+      borrower,
+      secondPrincipal
+    );
+    _requestTransfer(borrower, secondPrincipal);
+
+    assertEq(market.borrower(), borrower);
+    assertEq(market.borrowerPrincipal(), borrower);
+    assertEq(market.pendingBorrower(), secondPrincipal);
+    assertEq(_marketStateHash(), stateHash, 'sequential market state changed');
+
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
+    market.setMaxTotalSupply(DefaultMaximumSupply - 1);
+  }
+
+  function test_requestBorrowerTransfer_ReplacesPendingTarget() external {
+    _registerPrincipal(secondPrincipal);
+    _registerPrincipal(thirdPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+
+    vm.expectEmit(address(market));
+    emit BorrowerTransferRequested(
+      borrower,
+      secondPrincipal,
+      thirdPrincipal,
+      borrower,
+      thirdPrincipal
+    );
+    _requestTransfer(borrower, thirdPrincipal);
+
+    assertEq(market.pendingBorrower(), thirdPrincipal);
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IMarketEventsAndErrors.NotPendingBorrower.selector);
+    market.acceptBorrowerTransfer();
+  }
+
+  function test_cancelBorrowerTransfer() external {
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+
+    vm.expectEmit(address(market));
+    emit BorrowerTransferCancelled(borrower, secondPrincipal, borrower);
+    vm.prank(borrower);
+    market.cancelBorrowerTransfer();
+
+    assertEq(market.pendingBorrower(), address(0));
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IMarketEventsAndErrors.NotPendingBorrower.selector);
+    market.acceptBorrowerTransfer();
+  }
+
+  function test_cancelBorrowerTransfer_RemainsAvailableWhileBorrowerIsSanctioned() external {
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+    sanctionsSentinel.sanction(borrower);
+
+    vm.prank(borrower);
+    market.cancelBorrowerTransfer();
+
+    assertEq(market.pendingBorrower(), address(0));
+  }
+
+  function test_cancelBorrowerTransfer_NoPendingTransfer() external {
+    vm.prank(borrower);
+    vm.expectRevert(IMarketEventsAndErrors.NoPendingBorrowerTransfer.selector);
+    market.cancelBorrowerTransfer();
+  }
+
+  function test_borrowerTransfer_Authorization() external {
+    _registerPrincipal(secondPrincipal);
+
+    vm.prank(alice);
+    vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
+    market.requestBorrowerTransfer(secondPrincipal);
+
+    _requestTransfer(borrower, secondPrincipal);
+
+    vm.prank(alice);
+    vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
+    market.cancelBorrowerTransfer();
+
+    vm.prank(alice);
+    vm.expectRevert(IMarketEventsAndErrors.NotPendingBorrower.selector);
+    market.acceptBorrowerTransfer();
+  }
+
+  function test_requestBorrowerTransfer_InvalidTargets() external {
+    vm.startPrank(borrower);
+    vm.expectRevert(IMarketEventsAndErrors.InvalidBorrowerTransferTarget.selector);
+    market.requestBorrowerTransfer(address(0));
+
+    vm.expectRevert(IMarketEventsAndErrors.InvalidBorrowerTransferTarget.selector);
+    market.requestBorrowerTransfer(borrower);
+
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerIdentityNotFound.selector);
+    market.requestBorrowerTransfer(address(0xBAD));
+    vm.stopPrank();
+  }
+
+  function test_acceptBorrowerTransfer_DirectPrincipalToDirectPrincipal() external {
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+    bytes32 stateHash = _marketStateHash();
+
+    _expectTransfer(borrower, secondPrincipal, borrower, secondPrincipal);
+
+    assertEq(market.borrower(), secondPrincipal);
+    assertEq(market.borrowerPrincipal(), secondPrincipal);
+    assertEq(market.pendingBorrower(), address(0));
+    assertEq(_marketStateHash(), stateHash, 'sequential market state changed');
+
+    _registerPrincipal(thirdPrincipal);
+    vm.prank(borrower);
+    vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
+    market.requestBorrowerTransfer(thirdPrincipal);
+
+    _requestTransfer(secondPrincipal, thirdPrincipal);
+    assertEq(market.pendingBorrower(), thirdPrincipal);
+  }
+
+  function test_acceptBorrowerTransfer_DirectPrincipalToAccount() external {
+    address account = _deployAccount(borrower);
+    _requestTransfer(borrower, account);
+
+    _expectTransfer(borrower, account, borrower, borrower);
+
+    assertEq(market.borrower(), account);
+    assertEq(market.borrowerPrincipal(), borrower);
+  }
+
+  function test_acceptBorrowerTransfer_AccountRotation() external {
+    address firstAccount = _deployAccount(borrower);
+    address secondAccount = _deployAccount(borrower);
+    _requestTransfer(borrower, firstAccount);
+    _acceptTransfer(firstAccount);
+
+    _requestTransfer(firstAccount, secondAccount);
+    _expectTransfer(firstAccount, secondAccount, borrower, borrower);
+
+    assertEq(market.borrower(), secondAccount);
+    assertEq(market.borrowerPrincipal(), borrower);
+  }
+
+  function test_acceptBorrowerTransfer_AccountToDirectPrincipal() external {
+    address account = _deployAccount(borrower);
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, account);
+    _acceptTransfer(account);
+
+    _requestTransfer(account, secondPrincipal);
+    _expectTransfer(account, secondPrincipal, borrower, secondPrincipal);
+
+    assertEq(market.borrower(), secondPrincipal);
+    assertEq(market.borrowerPrincipal(), secondPrincipal);
+  }
+
+  function test_acceptBorrowerTransfer_AccountToAccountOfNewPrincipal() external {
+    address firstAccount = _deployAccount(borrower);
+    address secondAccount = _deployAccount(secondPrincipal);
+    _requestTransfer(borrower, firstAccount);
+    _acceptTransfer(firstAccount);
+
+    _requestTransfer(firstAccount, secondAccount);
+    _expectTransfer(firstAccount, secondAccount, borrower, secondPrincipal);
+
+    assertEq(market.borrower(), secondAccount);
+    assertEq(market.borrowerPrincipal(), secondPrincipal);
+  }
+
+  function test_acceptBorrowerTransfer_AccountSurvivesFactoryRemoval() external {
+    address account = _deployAccount(borrower);
+    borrowerIdentityRegistry.removeAccountFactory(address(accountFactory));
+
+    _requestTransfer(borrower, account);
+    _acceptTransfer(account);
+
+    assertEq(market.borrower(), account);
+    assertEq(market.borrowerPrincipal(), borrower);
+  }
+
+  function test_acceptBorrowerTransfer_RevalidatesDirectPrincipalRegistration() external {
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+    archController.removeBorrower(secondPrincipal);
+
+    vm.prank(secondPrincipal);
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerIdentityNotFound.selector);
+    market.acceptBorrowerTransfer();
+
+    assertEq(market.borrower(), borrower);
+    assertEq(market.pendingBorrower(), secondPrincipal);
+  }
+
+  function test_acceptBorrowerTransfer_RevalidatesAccountPrincipalRegistration() external {
+    address account = _deployAccount(secondPrincipal);
+    _requestTransfer(borrower, account);
+    archController.removeBorrower(secondPrincipal);
+
+    vm.prank(account);
+    vm.expectRevert(IBorrowerIdentityRegistry.BorrowerPrincipalNotRegistered.selector);
+    market.acceptBorrowerTransfer();
+
+    assertEq(market.borrower(), borrower);
+    assertEq(market.pendingBorrower(), account);
+  }
+
+  function test_acceptBorrowerTransfer_RevalidatesAmbiguousIdentity() external {
+    address account = _deployAccount(secondPrincipal);
+    _requestTransfer(borrower, account);
+    archController.registerBorrower(account);
+
+    vm.prank(account);
+    vm.expectRevert(IBorrowerIdentityRegistry.AmbiguousBorrowerIdentity.selector);
+    market.acceptBorrowerTransfer();
+
+    assertEq(market.borrower(), borrower);
+    assertEq(market.pendingBorrower(), account);
+  }
+
+  function test_requestBorrowerTransfer_RejectsRawSanctionsDespiteOverride() external {
+    _registerPrincipal(secondPrincipal);
+    sanctionsSentinel.sanction(borrower);
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(borrower);
+
+    vm.prank(borrower);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IMarketEventsAndErrors.BorrowerTransferWhileSanctioned.selector,
+        borrower
+      )
+    );
+    market.requestBorrowerTransfer(secondPrincipal);
+  }
+
+  function test_requestBorrowerTransfer_RejectsSanctionedTarget() external {
+    _registerPrincipal(secondPrincipal);
+    sanctionsSentinel.sanction(secondPrincipal);
+
+    vm.prank(borrower);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IMarketEventsAndErrors.BorrowerTransferWhileSanctioned.selector,
+        secondPrincipal
+      )
+    );
+    market.requestBorrowerTransfer(secondPrincipal);
+  }
+
+  function test_acceptBorrowerTransfer_RevalidatesCurrentPrincipalSanctions() external {
+    address account = _deployAccount(borrower);
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, account);
+    _acceptTransfer(account);
+    _requestTransfer(account, secondPrincipal);
+    sanctionsSentinel.sanction(borrower);
+
+    vm.prank(secondPrincipal);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IMarketEventsAndErrors.BorrowerTransferWhileSanctioned.selector,
+        borrower
+      )
+    );
+    market.acceptBorrowerTransfer();
+  }
+
+  function test_acceptBorrowerTransfer_RevalidatesTargetAccountSanctions() external {
+    address account = _deployAccount(secondPrincipal);
+    _requestTransfer(borrower, account);
+    sanctionsSentinel.sanction(account);
+
+    vm.prank(account);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IMarketEventsAndErrors.BorrowerTransferWhileSanctioned.selector,
+        account
+      )
+    );
+    market.acceptBorrowerTransfer();
+  }
+
+  function test_acceptBorrowerTransfer_RevalidatesTargetPrincipalSanctions() external {
+    address account = _deployAccount(secondPrincipal);
+    _requestTransfer(borrower, account);
+    sanctionsSentinel.sanction(secondPrincipal);
+
+    vm.prank(account);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        IMarketEventsAndErrors.BorrowerTransferWhileSanctioned.selector,
+        secondPrincipal
+      )
+    );
+    market.acceptBorrowerTransfer();
+  }
+
+  function test_acceptBorrowerTransfer_ActiveMarketPreservesAccounting() external {
+    _deposit(alice, 10e18);
+    _borrow(4e18);
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+    bytes32 stateHash = _marketStateHash();
+
+    _acceptTransfer(secondPrincipal);
+
+    assertEq(_marketStateHash(), stateHash, 'active market accounting changed');
+  }
+
+  function test_acceptBorrowerTransfer_DelinquentMarketPreservesAccounting() external {
+    _depositBorrowWithdraw(alice, 10e18, 8e18, 10e18);
+    assertTrue(market.currentState().isDelinquent, 'market should be delinquent');
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+    bytes32 stateHash = _marketStateHash();
+
+    _acceptTransfer(secondPrincipal);
+
+    assertEq(_marketStateHash(), stateHash, 'delinquent market accounting changed');
+  }
+
+  function test_acceptBorrowerTransfer_ClosedMarketPreservesAccounting() external {
+    _closeMarket();
+    _registerPrincipal(secondPrincipal);
+    _requestTransfer(borrower, secondPrincipal);
+    bytes32 stateHash = _marketStateHash();
+
+    _acceptTransfer(secondPrincipal);
+
+    assertTrue(market.isClosed());
+    assertEq(_marketStateHash(), stateHash, 'closed market accounting changed');
+  }
+
+  function testFuzz_borrowerTransferReplacementAcceptsOnlyLatestTarget(
+    uint160 firstSeed,
+    uint160 secondSeed
+  ) external {
+    address firstTarget = address(uint160(bound(firstSeed, 1, type(uint160).max)));
+    address secondTarget = address(uint160(bound(secondSeed, 1, type(uint160).max)));
+    vm.assume(firstTarget != borrower);
+    vm.assume(secondTarget != borrower && secondTarget != firstTarget);
+    _registerPrincipal(firstTarget);
+    _registerPrincipal(secondTarget);
+
+    _requestTransfer(borrower, firstTarget);
+    _requestTransfer(borrower, secondTarget);
+
+    vm.prank(firstTarget);
+    vm.expectRevert(IMarketEventsAndErrors.NotPendingBorrower.selector);
+    market.acceptBorrowerTransfer();
+
+    _acceptTransfer(secondTarget);
+    assertEq(market.borrower(), secondTarget);
+    assertEq(market.borrowerPrincipal(), secondTarget);
+    assertEq(market.pendingBorrower(), address(0));
+  }
+}

--- a/test/market/WildcatMarketBorrowerTransfer.t.sol
+++ b/test/market/WildcatMarketBorrowerTransfer.t.sol
@@ -3,6 +3,10 @@ pragma solidity >=0.8.20;
 
 import '../BaseMarketTest.sol';
 import 'src/interfaces/IBorrowerIdentityRegistry.sol';
+import 'src/interfaces/IWildcatSanctionsEscrow.sol';
+import 'src/vault/Wildcat4626Wrapper.sol';
+import { MockChainalysis } from '../shared/mocks/MockChainalysis.sol';
+import { MockERC20 } from 'solmate/test/utils/mocks/MockERC20.sol';
 
 contract BorrowerTransferTestAccount {}
 
@@ -50,6 +54,32 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
   function _acceptTransfer(address newBorrower) internal {
     vm.prank(newBorrower);
     market.acceptBorrowerTransfer();
+  }
+
+  function _transferBorrower(address currentBorrower, address newBorrower) internal {
+    _requestTransfer(currentBorrower, newBorrower);
+    _acceptTransfer(newBorrower);
+  }
+
+  function _clearSanction(address account) internal {
+    MockChainalysis(sanctionsSentinel.chainalysisSanctionsList()).unsanction(account);
+  }
+
+  function _deployWrapper() internal returns (Wildcat4626Wrapper wrapper) {
+    wrapper = Wildcat4626Wrapper(wrapperFactory.createWrapper(address(market)));
+    _authorizeLender(address(wrapper));
+  }
+
+  function _wrap(
+    Wildcat4626Wrapper wrapper,
+    address account,
+    uint256 amount
+  ) internal returns (uint256 shares) {
+    _deposit(account, amount);
+    vm.startPrank(account);
+    market.approve(address(wrapper), amount);
+    shares = wrapper.deposit(amount, account);
+    vm.stopPrank();
   }
 
   function _marketStateHash() internal view returns (bytes32 result) {
@@ -258,6 +288,210 @@ contract WildcatMarketBorrowerTransferTest is BaseMarketTest {
 
     assertEq(market.borrower(), account);
     assertEq(market.borrowerPrincipal(), borrower);
+  }
+
+  function test_borrowerAccountDrawChecksOperationalBorrowerAndPrincipal() external {
+    _deposit(alice, 10e18);
+    address account = _deployAccount(borrower);
+    _transferBorrower(borrower, account);
+
+    sanctionsSentinel.sanction(account);
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(account);
+
+    vm.prank(account);
+    vm.expectRevert(IMarketEventsAndErrors.BorrowWhileSanctioned.selector);
+    market.borrow(1e18);
+
+    _clearSanction(account);
+    sanctionsSentinel.sanction(borrower);
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(borrower);
+
+    vm.prank(account);
+    vm.expectRevert(IMarketEventsAndErrors.BorrowWhileSanctioned.selector);
+    market.borrow(1e18);
+  }
+
+  function test_samePrincipalAccountRotationPreservesLenderSanctionsOverride() external {
+    Wildcat4626Wrapper wrapper = _deployWrapper();
+    address firstAccount = _deployAccount(borrower);
+    address secondAccount = _deployAccount(borrower);
+
+    sanctionsSentinel.sanction(alice);
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(alice);
+
+    _transferBorrower(borrower, firstAccount);
+    _transferBorrower(firstAccount, secondAccount);
+
+    vm.prank(alice);
+    market.deposit(1e18);
+
+    assertEq(market.borrower(), secondAccount);
+    assertEq(market.borrowerPrincipal(), borrower);
+    assertGt(wrapper.maxDeposit(alice), 0, 'wrapper lost principal override');
+  }
+
+  function test_principalMigrationStartsNewLenderSanctionsNamespace() external {
+    Wildcat4626Wrapper wrapper = _deployWrapper();
+    address account = _deployAccount(secondPrincipal);
+
+    sanctionsSentinel.sanction(alice);
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(alice);
+    _transferBorrower(borrower, account);
+
+    assertFalse(sanctionsSentinel.isSanctioned(borrower, alice));
+    assertTrue(sanctionsSentinel.isSanctioned(secondPrincipal, alice));
+
+    vm.prank(alice);
+    vm.expectRevert(IMarketEventsAndErrors.AccountBlocked.selector);
+    market.deposit(1e18);
+    assertEq(wrapper.maxDeposit(alice), 0, 'wrapper retained old principal override');
+
+    vm.prank(secondPrincipal);
+    sanctionsSentinel.overrideSanction(alice);
+    vm.prank(alice);
+    market.deposit(1e18);
+    assertGt(wrapper.maxDeposit(alice), 0, 'wrapper ignored new principal override');
+  }
+
+  function test_sanctionedWithdrawalUsesPrincipalNamespace() external {
+    address account = _deployAccount(secondPrincipal);
+    _transferBorrower(borrower, account);
+    _deposit(alice, 10e18);
+    sanctionsSentinel.sanction(alice);
+
+    market.nukeFromOrbit(alice);
+    uint32 expiry = market.previousState().pendingWithdrawalExpiry;
+    fastForward(parameters.withdrawalBatchDuration + 1);
+    market.updateState();
+    market.executeWithdrawal(alice, expiry);
+
+    address principalEscrow = sanctionsSentinel.getEscrowAddress(
+      secondPrincipal,
+      alice,
+      address(asset)
+    );
+    address accountEscrow = sanctionsSentinel.getEscrowAddress(account, alice, address(asset));
+
+    assertTrue(principalEscrow != accountEscrow, 'escrow namespaces collided');
+    assertGt(asset.balanceOf(principalEscrow), 0, 'principal escrow was not funded');
+    assertEq(accountEscrow.code.length, 0, 'operational account escrow was deployed');
+    assertEq(IWildcatSanctionsEscrow(principalEscrow).borrower(), secondPrincipal);
+  }
+
+  function test_existingMarketEscrowRemainsReleasableAfterPrincipalMigration() external {
+    _deposit(alice, 10e18);
+    sanctionsSentinel.sanction(alice);
+    market.nukeFromOrbit(alice);
+    uint32 expiry = market.previousState().pendingWithdrawalExpiry;
+    fastForward(parameters.withdrawalBatchDuration + 1);
+    market.updateState();
+    market.executeWithdrawal(alice, expiry);
+
+    address escrow = sanctionsSentinel.getEscrowAddress(borrower, alice, address(asset));
+    uint256 escrowedAmount = asset.balanceOf(escrow);
+    assertGt(escrowedAmount, 0, 'old escrow was not funded');
+
+    _registerPrincipal(secondPrincipal);
+    _transferBorrower(borrower, secondPrincipal);
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(alice);
+
+    uint256 balanceBefore = asset.balanceOf(alice);
+    IWildcatSanctionsEscrow(escrow).releaseEscrow();
+
+    assertEq(asset.balanceOf(alice), balanceBefore + escrowedAmount);
+    assertTrue(sanctionsSentinel.isSanctioned(secondPrincipal, alice));
+  }
+
+  function test_existingWrapperEscrowRemainsReleasableAfterPrincipalMigration() external {
+    Wildcat4626Wrapper wrapper = _deployWrapper();
+    uint256 shares = _wrap(wrapper, alice, 10e18);
+    sanctionsSentinel.sanction(alice);
+    wrapper.nukeFromOrbit(alice);
+
+    address escrow = sanctionsSentinel.getEscrowAddress(borrower, alice, address(wrapper));
+    assertEq(wrapper.balanceOf(escrow), shares, 'old wrapper escrow was not funded');
+
+    _registerPrincipal(secondPrincipal);
+    _transferBorrower(borrower, secondPrincipal);
+    assertTrue(sanctionsSentinel.isSanctioned(secondPrincipal, alice));
+    sanctionsSentinel.sanction(escrow);
+
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(alice);
+    IWildcatSanctionsEscrow(escrow).releaseEscrow();
+
+    assertEq(wrapper.balanceOf(alice), shares, 'old wrapper escrow did not release');
+    assertEq(wrapper.balanceOf(escrow), 0, 'old wrapper escrow retained shares');
+    assertTrue(sanctionsSentinel.isSanctioned(secondPrincipal, alice));
+  }
+
+  function test_existingWrapperEscrowRemainsReleasableAfterNewPrincipalOverride() external {
+    Wildcat4626Wrapper wrapper = _deployWrapper();
+    uint256 shares = _wrap(wrapper, alice, 10e18);
+    sanctionsSentinel.sanction(alice);
+    wrapper.nukeFromOrbit(alice);
+
+    address escrow = sanctionsSentinel.getEscrowAddress(borrower, alice, address(wrapper));
+    assertEq(wrapper.balanceOf(escrow), shares, 'old wrapper escrow was not funded');
+
+    _registerPrincipal(secondPrincipal);
+    _transferBorrower(borrower, secondPrincipal);
+    sanctionsSentinel.sanction(escrow);
+
+    vm.prank(borrower);
+    sanctionsSentinel.overrideSanction(alice);
+    vm.prank(secondPrincipal);
+    sanctionsSentinel.overrideSanction(alice);
+    IWildcatSanctionsEscrow(escrow).releaseEscrow();
+
+    assertEq(wrapper.balanceOf(alice), shares, 'old wrapper escrow did not release');
+    assertEq(wrapper.balanceOf(escrow), 0, 'old wrapper escrow retained shares');
+    assertFalse(sanctionsSentinel.isSanctioned(secondPrincipal, alice));
+  }
+
+  function test_sanctionedWrapperSharesUsePrincipalNamespace() external {
+    Wildcat4626Wrapper wrapper = _deployWrapper();
+    uint256 shares = _wrap(wrapper, alice, 10e18);
+    address account = _deployAccount(secondPrincipal);
+    _transferBorrower(borrower, account);
+    sanctionsSentinel.sanction(alice);
+
+    wrapper.nukeFromOrbit(alice);
+
+    address principalEscrow = sanctionsSentinel.getEscrowAddress(
+      secondPrincipal,
+      alice,
+      address(wrapper)
+    );
+    address accountEscrow = sanctionsSentinel.getEscrowAddress(account, alice, address(wrapper));
+
+    assertTrue(principalEscrow != accountEscrow, 'escrow namespaces collided');
+    assertEq(wrapper.balanceOf(principalEscrow), shares, 'principal escrow was not funded');
+    assertEq(accountEscrow.code.length, 0, 'operational account escrow was deployed');
+    assertEq(IWildcatSanctionsEscrow(principalEscrow).borrower(), secondPrincipal);
+  }
+
+  function test_wrapperSweepAuthorityFollowsOperationalBorrower() external {
+    Wildcat4626Wrapper wrapper = _deployWrapper();
+    address account = _deployAccount(borrower);
+    MockERC20 stray = new MockERC20('Stray', 'STRAY', 18);
+    stray.mint(address(wrapper), 10e18);
+
+    _transferBorrower(borrower, account);
+
+    assertEq(wrapper.marketOwner(), account);
+    vm.prank(borrower);
+    vm.expectRevert(Wildcat4626Wrapper.NotMarketOwner.selector);
+    wrapper.sweep(address(stray), borrower);
+
+    vm.prank(account);
+    wrapper.sweep(address(stray), account);
+    assertEq(stray.balanceOf(account), 10e18);
   }
 
   function test_acceptBorrowerTransfer_RevalidatesDirectPrincipalRegistration() external {

--- a/test/market/WildcatMarketConfig.t.sol
+++ b/test/market/WildcatMarketConfig.t.sol
@@ -37,6 +37,9 @@ contract MockPendingAprReductionHooks is MockHooks {
 contract WildcatMarketConfigTest is BaseMarketTest {
   using MathUtils for uint;
 
+  bytes32 internal constant BORROWER_STORAGE_SLOT =
+    bytes32(uint256(keccak256('wildcat.market.borrower')) - 1);
+
   MockPendingAprReductionHooks internal aprReductionHooks;
 
   function resetWithMockPendingAprReductionHooks() internal asSelf {
@@ -87,6 +90,31 @@ contract WildcatMarketConfigTest is BaseMarketTest {
 
   function test_reserveRatioBips() external asAccount(borrower) {
     assertEq(market.reserveRatioBips(), parameters.reserveRatioBips);
+  }
+
+  function test_borrowerReadsFromNamespacedStorage() external {
+    assertEq(
+      address(uint160(uint256(vm.load(address(market), BORROWER_STORAGE_SLOT)))),
+      borrower,
+      'stored borrower'
+    );
+
+    address newBorrower = address(0xB0B);
+    vm.store(
+      address(market),
+      BORROWER_STORAGE_SLOT,
+      bytes32(uint256(uint160(newBorrower)))
+    );
+
+    assertEq(market.borrower(), newBorrower, 'borrower getter');
+
+    vm.prank(borrower);
+    vm.expectRevert(IMarketEventsAndErrors.NotApprovedBorrower.selector);
+    market.setMaxTotalSupply(1);
+
+    vm.prank(newBorrower);
+    market.setMaxTotalSupply(1);
+    assertEq(market.maxTotalSupply(), 1, 'new borrower authority');
   }
 
   // ========================================================================== //

--- a/test/market/WildcatMarketRevolving.t.sol
+++ b/test/market/WildcatMarketRevolving.t.sol
@@ -292,6 +292,10 @@ contract WildcatMarketRevolvingTest is Test {
     assertEq(revolvingMarket.drawnAmount(), 0);
   }
 
+  function test_borrowerPrincipal_initializesToBorrower() external view {
+    assertEq(market.borrowerPrincipal(), borrower);
+  }
+
   function test_borrow_updatesDrawnAmount() external {
     _deposit(lender, 1_000e18);
     market.borrow(400e18);

--- a/test/market/WildcatMarketRevolving.t.sol
+++ b/test/market/WildcatMarketRevolving.t.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.19;
 
 import 'forge-std/Test.sol';
 import 'src/WildcatArchController.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
 import 'src/HooksFactoryRevolving.sol';
 import 'src/libraries/LibStoredInitCode.sol';
 import 'src/market/WildcatMarket.sol';
@@ -22,6 +23,7 @@ contract WildcatMarketRevolvingTest is Test {
   using FeeMath for MarketState;
 
   WildcatArchController internal archController;
+  WildcatBorrowerIdentityRegistry internal borrowerIdentityRegistry;
   HooksFactoryRevolving internal hooksFactoryRevolving;
   MockSanctionsSentinel internal sanctionsSentinel;
   MockERC20 internal underlying;
@@ -52,6 +54,7 @@ contract WildcatMarketRevolvingTest is Test {
     borrower = address(this);
     deployMockChainalysis();
     archController = new WildcatArchController();
+    borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(address(archController));
     sanctionsSentinel = new MockSanctionsSentinel(address(archController));
     (address marketTemplate, uint256 marketInitCodeHash) = _storeMarketInitCode();
     hooksFactoryRevolving = new HooksFactoryRevolving(
@@ -59,7 +62,8 @@ contract WildcatMarketRevolvingTest is Test {
       address(sanctionsSentinel),
       address(this),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
     archController.registerControllerFactory(address(hooksFactoryRevolving));
     hooksFactoryRevolving.registerWithArchController();
@@ -294,6 +298,27 @@ contract WildcatMarketRevolvingTest is Test {
 
   function test_borrowerPrincipal_initializesToBorrower() external view {
     assertEq(market.borrowerPrincipal(), borrower);
+  }
+
+  function test_borrowerTransfer_preservesDrawnAmountAndStorageSlot() external {
+    _deposit(lender, 1_000e18);
+    market.borrow(400e18);
+    uint256 drawnAmountSlot = stdstore
+      .target(address(revolvingMarket))
+      .sig(IWildcatMarketRevolving.drawnAmount.selector)
+      .find();
+    bytes32 drawnAmountSlotBefore = vm.load(address(market), bytes32(drawnAmountSlot));
+    address newBorrower = address(0xB0B);
+    archController.registerBorrower(newBorrower);
+
+    market.requestBorrowerTransfer(newBorrower);
+    vm.prank(newBorrower);
+    market.acceptBorrowerTransfer();
+
+    assertEq(market.borrower(), newBorrower);
+    assertEq(market.borrowerPrincipal(), newBorrower);
+    assertEq(revolvingMarket.drawnAmount(), 400e18);
+    assertEq(vm.load(address(market), bytes32(drawnAmountSlot)), drawnAmountSlotBefore);
   }
 
   function test_borrow_updatesDrawnAmount() external {

--- a/test/market/WildcatMarketRevolving.t.sol
+++ b/test/market/WildcatMarketRevolving.t.sol
@@ -17,6 +17,7 @@ import { MockSanctionsSentinel } from '../shared/mocks/MockSanctionsSentinel.sol
 import { deployMockChainalysis } from '../shared/mocks/MockChainalysis.sol';
 
 contract WildcatMarketRevolvingTest is Test {
+  using stdStorage for StdStorage;
   using MathUtils for uint256;
   using FeeMath for MarketState;
 
@@ -538,7 +539,11 @@ contract WildcatMarketRevolvingTest is Test {
     _deposit(lender, 1_000e18);
 
     // Force drawnAmount > totalSupply so utilization is clamped to 100%.
-    vm.store(address(market), bytes32(uint256(10)), bytes32(uint256(2_000e18)));
+    uint256 drawnAmountSlot = stdstore
+      .target(address(revolvingMarket))
+      .sig(IWildcatMarketRevolving.drawnAmount.selector)
+      .find();
+    vm.store(address(market), bytes32(drawnAmountSlot), bytes32(uint256(2_000e18)));
 
     vm.warp(block.timestamp + 365 days);
     market.updateState();

--- a/test/shared/Test.sol
+++ b/test/shared/Test.sol
@@ -540,6 +540,7 @@ contract Test is ForgeTest, Prankster, Assertions {
     assertEq(market.annualInterestBips(), parameters.annualInterestBips, 'annualInterestBips');
     assertEq(market.reserveRatioBips(), parameters.reserveRatioBips, 'reserveRatioBips');
     assertEq(market.borrower(), parameters.borrower, 'borrower');
+    assertEq(market.borrowerPrincipal(), parameters.borrower, 'borrowerPrincipal');
     assertEq(market.archController(), address(archController), 'archController');
     assertEq(market.feeRecipient(), parameters.feeRecipient, 'feeRecipient');
     assertEq(market.factory(), address(hooksFactory), 'factory');

--- a/test/shared/Test.sol
+++ b/test/shared/Test.sol
@@ -546,6 +546,7 @@ contract Test is ForgeTest, Prankster, Assertions {
     assertEq(market.borrower(), parameters.borrower, 'borrower');
     assertEq(market.borrowerPrincipal(), parameters.borrower, 'borrowerPrincipal');
     assertEq(market.pendingBorrower(), address(0), 'pendingBorrower');
+    assertEq(market.pendingBorrowerPrincipal(), address(0), 'pendingBorrowerPrincipal');
     assertEq(
       market.borrowerIdentityRegistry(),
       address(borrowerIdentityRegistry),

--- a/test/shared/Test.sol
+++ b/test/shared/Test.sol
@@ -7,6 +7,7 @@ import { VmSafe } from 'forge-std/Vm.sol';
 import { Prankster } from 'sol-utils/test/Prankster.sol';
 
 import 'src/WildcatArchController.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
 import '../helpers/VmUtils.sol' as VmUtils;
 import '../helpers/Assertions.sol';
 import { MockEngine } from './mocks/MockEngine.sol';
@@ -53,6 +54,7 @@ contract Test is ForgeTest, Prankster, Assertions {
   HooksFactory internal hooksFactory;
   Wildcat4626WrapperFactory internal wrapperFactory;
   WildcatArchController internal archController;
+  WildcatBorrowerIdentityRegistry internal borrowerIdentityRegistry;
   OpenTermHooks internal hooks;
   WildcatMarket internal market;
   MockSanctionsSentinel internal sanctionsSentinel;
@@ -99,6 +101,7 @@ contract Test is ForgeTest, Prankster, Assertions {
   function deployBaseContracts(bool withEngine) internal asSelf {
     deployMockChainalysis();
     archController = new WildcatArchController();
+    borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(address(archController));
     if (withEngine) {
       deploySphereXEngine();
     } else {
@@ -115,7 +118,8 @@ contract Test is ForgeTest, Prankster, Assertions {
       address(sanctionsSentinel),
       address(wrapperFactory),
       marketTemplate,
-      marketInitCodeHash
+      marketInitCodeHash,
+      address(borrowerIdentityRegistry)
     );
 
     // Register the hooks factory as a controller factory so it can register
@@ -541,6 +545,12 @@ contract Test is ForgeTest, Prankster, Assertions {
     assertEq(market.reserveRatioBips(), parameters.reserveRatioBips, 'reserveRatioBips');
     assertEq(market.borrower(), parameters.borrower, 'borrower');
     assertEq(market.borrowerPrincipal(), parameters.borrower, 'borrowerPrincipal');
+    assertEq(market.pendingBorrower(), address(0), 'pendingBorrower');
+    assertEq(
+      market.borrowerIdentityRegistry(),
+      address(borrowerIdentityRegistry),
+      'borrowerIdentityRegistry'
+    );
     assertEq(market.archController(), address(archController), 'archController');
     assertEq(market.feeRecipient(), parameters.feeRecipient, 'feeRecipient');
     assertEq(market.factory(), address(hooksFactory), 'factory');

--- a/test/vault/Wildcat4626Wrapper.t.sol
+++ b/test/vault/Wildcat4626Wrapper.t.sol
@@ -53,6 +53,22 @@ contract MockErc20 {
   }
 }
 
+contract SpoofSanctionsEscrow {
+  address public immutable borrower;
+
+  constructor(address borrower_) {
+    borrower = borrower_;
+  }
+
+  function transferShares(
+    Wildcat4626Wrapper wrapper,
+    address to,
+    uint256 amount
+  ) external {
+    wrapper.transfer(to, amount);
+  }
+}
+
 contract MockMarketToken is IWildcatMarketToken {
   using MathUtils for uint256;
 
@@ -61,7 +77,8 @@ contract MockMarketToken is IWildcatMarketToken {
   uint8 public immutable override decimals;
 
   uint256 public override scaleFactor;
-  address public immutable override borrower;
+  address public override borrower;
+  address public override borrowerPrincipal;
   address public immutable override sentinel;
   address public immutable override wrapperFactory;
 
@@ -74,6 +91,7 @@ contract MockMarketToken is IWildcatMarketToken {
     decimals = tokenDecimals;
     scaleFactor = RAY;
     borrower = borrower_;
+    borrowerPrincipal = borrower_;
     sentinel = sentinel_;
     wrapperFactory = msg.sender;
   }
@@ -97,6 +115,11 @@ contract MockMarketToken is IWildcatMarketToken {
   function setScaleFactor(uint256 newScaleFactor) external {
     require(newScaleFactor != 0, 'ZERO_FACTOR');
     scaleFactor = newScaleFactor;
+  }
+
+  function setBorrower(address borrower_, address principal_) external {
+    borrower = borrower_;
+    borrowerPrincipal = principal_;
   }
 
   function nukeFromOrbit(address) external {
@@ -344,6 +367,28 @@ contract Wildcat4626WrapperTest is Test {
     vm.expectRevert(Wildcat4626Wrapper.NotMarketOwner.selector);
     vm.prank(FED);
     wrapper.sweep(address(stray), FED);
+  }
+
+  function testFuzz_sweepAuthorityFollowsCurrentBorrower(
+    uint160 borrowerSeed,
+    uint96 amountSeed
+  ) external {
+    address nextBorrower = address(uint160(bound(borrowerSeed, 1, type(uint160).max)));
+    vm.assume(nextBorrower != BORROWER);
+    uint256 amount = bound(amountSeed, 1, type(uint96).max);
+    MockErc20 stray = new MockErc20();
+    stray.mint(address(wrapper), amount);
+    market.setBorrower(nextBorrower, BORROWER);
+
+    assertEq(wrapper.marketOwner(), nextBorrower, 'market owner did not follow borrower');
+
+    vm.expectRevert(Wildcat4626Wrapper.NotMarketOwner.selector);
+    vm.prank(BORROWER);
+    wrapper.sweep(address(stray), BORROWER);
+
+    vm.prank(nextBorrower);
+    assertEq(wrapper.sweep(address(stray), nextBorrower), amount, 'wrong swept amount');
+    assertEq(stray.balanceOf(nextBorrower), amount, 'new borrower did not receive sweep');
   }
 
   function test_sweepMarketAssetRevertsWhenNoStrandedBalance() external {
@@ -704,6 +749,18 @@ contract Wildcat4626WrapperTest is Test {
     wrapper.transfer(BOB, 1e18);
   }
 
+  function test_transferRejectsSpoofedOldEscrow() external {
+    SpoofSanctionsEscrow spoof = new SpoofSanctionsEscrow(BORROWER);
+    vm.startPrank(FED);
+    wrapper.deposit(5e18, FED);
+    wrapper.transfer(address(spoof), 1e18);
+    vm.stopPrank();
+    sanctionsSentinel.sanction(BOB);
+
+    vm.expectRevert(abi.encodeWithSelector(Wildcat4626Wrapper.SanctionedAccount.selector, BOB));
+    spoof.transferShares(wrapper, BOB, 1e18);
+  }
+
   function test_mint_revertsForSanctionedCaller() external {
     sanctionsSentinel.sanction(FED);
     vm.expectRevert(abi.encodeWithSelector(Wildcat4626Wrapper.SanctionedAccount.selector, FED));
@@ -821,6 +878,13 @@ contract Wildcat4626WrapperTest is Test {
   function test_constructor_revertsForZeroBorrower() external {
     // Deploy a market with zero borrower
     MockMarketToken badMarket = new MockMarketToken(18, address(0), address(sanctionsSentinel));
+    vm.expectRevert(Wildcat4626Wrapper.ZeroAddress.selector);
+    new Wildcat4626Wrapper(address(badMarket));
+  }
+
+  function test_constructor_revertsForZeroPrincipal() external {
+    MockMarketToken badMarket = new MockMarketToken(18, BORROWER, address(sanctionsSentinel));
+    badMarket.setBorrower(BORROWER, address(0));
     vm.expectRevert(Wildcat4626Wrapper.ZeroAddress.selector);
     new Wildcat4626Wrapper(address(badMarket));
   }

--- a/test/vault/Wildcat4626WrapperFactory.t.sol
+++ b/test/vault/Wildcat4626WrapperFactory.t.sol
@@ -21,6 +21,7 @@ contract StubMarketToken is IWildcatMarketToken {
 
   uint256 public override scaleFactor = RAY;
   address public immutable override borrower;
+  address public immutable override borrowerPrincipal;
   address public immutable override sentinel;
   address public immutable override wrapperFactory;
   address public registeredWrapper;
@@ -38,6 +39,7 @@ contract StubMarketToken is IWildcatMarketToken {
     address wrapperFactory_
   ) {
     borrower = borrower_;
+    borrowerPrincipal = borrower_;
     sentinel = sentinel_;
     _declaresFloorRounding = declaresFloorRounding_;
     wrapperFactory = wrapperFactory_;

--- a/test/vault/Wildcat4626WrapperGuards.t.sol
+++ b/test/vault/Wildcat4626WrapperGuards.t.sol
@@ -54,6 +54,7 @@ contract GuardMockMarket is IWildcatMarketToken {
 
   uint256 public override scaleFactor = RAY;
   address public immutable override borrower;
+  address public immutable override borrowerPrincipal;
   address public immutable override sentinel;
   address public immutable override wrapperFactory;
   uint256 internal _maxTotalSupply = type(uint128).max;
@@ -66,6 +67,7 @@ contract GuardMockMarket is IWildcatMarketToken {
   constructor(uint8 decimals_, address borrower_, address sentinel_) {
     decimals = decimals_;
     borrower = borrower_;
+    borrowerPrincipal = borrower_;
     sentinel = sentinel_;
     wrapperFactory = msg.sender;
   }

--- a/test/vault/Wildcat4626WrapperRounding.t.sol
+++ b/test/vault/Wildcat4626WrapperRounding.t.sol
@@ -27,6 +27,7 @@ contract MockMarketToken is IWildcatMarketToken {
 
   uint256 public override scaleFactor = RAY;
   address public immutable override borrower;
+  address public immutable override borrowerPrincipal;
   address public immutable override sentinel;
   address public immutable override wrapperFactory;
 
@@ -35,6 +36,7 @@ contract MockMarketToken is IWildcatMarketToken {
 
   constructor(address borrower_, address sentinel_) {
     borrower = borrower_;
+    borrowerPrincipal = borrower_;
     sentinel = sentinel_;
     wrapperFactory = msg.sender;
   }

--- a/test/vault/Wildcat4626WrapperStandard.t.sol
+++ b/test/vault/Wildcat4626WrapperStandard.t.sol
@@ -6,6 +6,7 @@ import 'src/vault/Wildcat4626Wrapper.sol';
 import 'src/vault/Wildcat4626WrapperFactory.sol';
 import { MockERC20 } from 'solmate/test/utils/mocks/MockERC20.sol';
 import { WildcatArchController } from 'src/WildcatArchController.sol';
+import { WildcatBorrowerIdentityRegistry } from 'src/WildcatBorrowerIdentityRegistry.sol';
 import { HooksFactory } from 'src/HooksFactory.sol';
 import { WildcatMarket } from 'src/market/WildcatMarket.sol';
 import { WildcatSanctionsSentinel } from 'src/WildcatSanctionsSentinel.sol';
@@ -19,6 +20,7 @@ contract Wildcat4626WrapperStandardTest is ERC4626Test {
   using HooksConfigLib for HooksConfig;
 
   WildcatArchController internal archController;
+  WildcatBorrowerIdentityRegistry internal borrowerIdentityRegistry;
   HooksFactory internal hooksFactory;
   WildcatSanctionsSentinel internal sanctionsSentinel;
   Wildcat4626WrapperFactory internal wrapperFactory;
@@ -31,6 +33,7 @@ contract Wildcat4626WrapperStandardTest is ERC4626Test {
 
   function setUp() public override {
     archController = new WildcatArchController();
+    borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(address(archController));
     MockChainalysis chainalysis = new MockChainalysis();
     sanctionsSentinel = new WildcatSanctionsSentinel(address(archController), address(chainalysis));
     wrapperFactory = new Wildcat4626WrapperFactory(address(archController), address(0));
@@ -44,7 +47,8 @@ contract Wildcat4626WrapperStandardTest is ERC4626Test {
       address(sanctionsSentinel),
       address(wrapperFactory),
       initCodeStorage,
-      initCodeHash
+      initCodeHash,
+      address(borrowerIdentityRegistry)
     );
 
     archController.registerControllerFactory(address(hooksFactory));


### PR DESCRIPTION
  ## Summary

  - Add two-step borrower transfers with principal/account validation and sanctions checks.
  - Move wrapper authority with the market borrower.
  - Expose transfer identity through the lens and support future v2.6 factories.

  ## Testing

  - forge test: 1,404 passed.
  - All production contracts remain below the EIP-170 size limit.