### PR TITLE
V25-ORG-02: Separate Hooks From Reusable Lender Lists

### DIFF
--- a/docs/Borrower Identity and Transfers.md
+++ b/docs/Borrower Identity and Transfers.md
@@ -140,6 +140,10 @@ A market transfer does not transfer its hooks or role providers. Hooks may be sh
 
 This separation is intentional. A market must not seize a shared hook or credential list merely because its borrower changed.
 
+Hook administration belongs to the principal and uses a separate two-step transfer. Acceptance updates the creating factory's administrator index, but it does not rewrite provider configuration, lender status, hook-local blocks, known-lender state, or hooked-market configuration.
+
+The v2.5 `AccessListRoleProvider` also has an independent two-step administrator transfer. Moving its administration preserves the provider address, membership, and every hook attachment. Other role providers are not assumed to implement that interface.
+
 ## Batching and atomicity
 
 Each market acceptance is atomic for that market. There is no protocol transfer manager and no Wildcat-controlled coordinator.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,7 +48,7 @@ inventory with per-file provenance is in [v2.5-audit-delta.md](./v2.5-audit-delt
 - Factory hardening: CREATE2 address verification on market deployment, pagination bounds validation (`InvalidPaginationRange`), empty-page handling.
 - `BaseAccessControls`: push credentials must have nonzero, non-future timestamps; `isPullProvider()` is probed defensively (non-implementing providers become push-only); providers already consulted via `hooksData` are skipped in the fallback pull loop.
 - Hook administration is now separate from credential ownership. Hooks no longer add their administrator as a permanent push provider, and hook administrators can move through a two-step transfer without rewriting provider configuration or lender state.
-- Added `AccessListRoleProvider`, a reusable pull provider with enumerable membership, bounded batch updates, and independent two-step administration. Added an authority-free CREATE2 factory that can assign the intended administrator even when deployment is initiated through a hook.
+- Added `AccessListRoleProvider`, a reusable pull provider with enumerable membership, explicit batch updates, and independent two-step administration. Its CREATE2 factory can assign the intended administrator when deployment is initiated through a hook and retains no authority after deployment.
 - TTL `0` now makes pull credentials non-cacheable, including within the same block. Positive TTLs retain the existing cache window, so delayed removal is an explicit hook configuration choice.
 - All three hook templates reject inconsistent access configurations (withdrawal access without deposit access, or without transfer access/disablement) at market creation.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,9 @@ inventory with per-file provenance is in [v2.5-audit-delta.md](./v2.5-audit-delt
 
 - Factory hardening: CREATE2 address verification on market deployment, pagination bounds validation (`InvalidPaginationRange`), empty-page handling.
 - `BaseAccessControls`: push credentials must have nonzero, non-future timestamps; `isPullProvider()` is probed defensively (non-implementing providers become push-only); providers already consulted via `hooksData` are skipped in the fallback pull loop.
+- Hook administration is now separate from credential ownership. Hooks no longer add their administrator as a permanent push provider, and hook administrators can move through a two-step transfer without rewriting provider configuration or lender state.
+- Added `AccessListRoleProvider`, a reusable pull provider with enumerable membership, bounded batch updates, and independent two-step administration. Added an authority-free CREATE2 factory that can assign the intended administrator even when deployment is initiated through a hook.
+- TTL `0` now makes pull credentials non-cacheable, including within the same block. Positive TTLs retain the existing cache window, so delayed removal is an explicit hook configuration choice.
 - All three hook templates reject inconsistent access configurations (withdrawal access without deposit access, or without transfer access/disablement) at market creation.
 
 ### Misc

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 - [Scale Factor](./Scale%20Factor.md) - explainer for the scaling of token amounts - critical for understanding the protocol
 - [Core behavior](./Core%20Behavior.md) - most important aspects of how the protocol operates
 - [Borrower identity and transfers](./Borrower%20Identity%20and%20Transfers.md) - operational borrower, legal principal, account registry, and two-step transfers in v2.5
+- [Role provider inventory](./Role%20Provider%20Inventory.md) - production, mock, and conceptual provider capabilities in the v2.5 source tree
 - [Terminology](./Terminology.md)
 - [Known issues](./Known%20Issues.md) - list of some things we know are issues or which might seem like issues but are intentional
 - [Changelog](./CHANGELOG.md) - changes between V1, V2, and V2.5

--- a/docs/Role Provider Inventory.md
+++ b/docs/Role Provider Inventory.md
@@ -1,0 +1,18 @@
+# Role Provider Inventory
+
+This is the repository-scoped inventory for the v2.5 provider migration. It distinguishes production contracts from test fixtures and examples. `IRoleProvider` remains ownership-agnostic; administration is a capability of a particular provider, not a property the hook assumes.
+
+| Provider | Location | Status | Credential model | Administration |
+| --- | --- | --- | --- | --- |
+| `AccessListRoleProvider` | `src/access/AccessListRoleProvider.sol` | v2.5 production candidate | Pull provider. Returns the current timestamp while an account is a member and zero otherwise. | `IManagedRoleProvider` two-step administrator transfer. Membership and provider address survive transfer. |
+| `UniversalProvider` | `script/mock/UniversalProvider.sol` | Local deployment mock | Pull and validation provider. Always returns the current timestamp. | Ownerless and immutable. |
+| `MockRoleProvider` | `test/shared/mocks/MockRoleProvider.sol` | Test fixture | Configurable pull, push, stored credential, or signature-validation behavior. | Unrestricted test setters; not a production authority model. |
+| `AlwaysAuthorizedRoleProvider` | `test/shared/mocks/AlwaysAuthorizedRoleProvider.sol` | Test fixture | Always returns the current timestamp. | Ownerless and immutable. |
+| EOA, Safe, or smart-account push provider | No provider contract required | Supported integration shape | Calls `grantRole` or `grantRoles` on a hook directly. The hook stores the pushed timestamp and TTL. | Defined by the calling account, not by `IRoleProvider`. |
+| Merkle-proof provider | No implementation in this repository | Example/future design only | `validateCredential` could verify a proof, but no root storage or persistence model is defined here. | Undefined until a concrete provider is designed. |
+
+No other production role-provider implementation was found in this repository. External providers may use different persistence and authority models, so SDK and migration tooling must probe optional capabilities rather than infer them from `IRoleProvider`.
+
+## Access-list factory provenance
+
+`AccessListRoleProviderFactory` emits the provider address, intended administrator, actual factory caller, caller-scoped salt, and initial member list. It has no owner, registry role, upgrade path, or callable authority over a deployed provider. The provider itself exposes current membership and paginated enumeration, so current state does not depend on replaying factory or membership events.

--- a/docs/hooks/templates/Access Control Hooks.md
+++ b/docs/hooks/templates/Access Control Hooks.md
@@ -1,8 +1,10 @@
 # Access Control Hooks
 
-In the access control hooks, the borrower can configure a set of "role providers" - accounts which grant credentials to lenders.
+The hook administrator configures a set of role providers that issue or validate lender credentials. The hook decides which providers it trusts and which market actions require access. It does not own the provider's credential list.
 
-Within the hooks contract, the borrower configures each provider with a TTL - the amount of time a credential granted by the provider is valid.
+Hook administration does not confer credential authority. A new hook does not add its administrator as a provider automatically. The administrator may attach an existing provider or create one through a compatible provider factory.
+
+The hook administrator configures each provider with a TTL, which controls how long the hook may use a credential without consulting the provider again.
 
 A role provider can be a push provider, a pull provider, or a validation provider depending on what it supports.
 All approved role providers can push credentials by calling `grantRole` or `grantRoles`.
@@ -31,11 +33,33 @@ For example, a role provider can be an EOA, multisig, or smart account that only
 Pull providers must implement `isPullProvider()` and `getCredential()`.
 Providers used with `hooksData` validation must implement `validateCredential()`.
 
+Role-provider administration is optional and separate from hook administration. `IRoleProvider` does not define an owner. A third-party, immutable, or ownerless provider remains valid if the hook administrator chooses to trust it.
+
+## Access-list role provider
+
+`AccessListRoleProvider` is the managed pull provider included with v2.5. One instance owns one reusable address list, and the same instance can be attached to several hooks. A borrower can deploy separate instances when two markets should not share a list.
+
+The current provider administrator may add or remove one member or an explicitly supplied batch. Members are enumerable, but removal uses swap-and-pop, so enumeration order is not stable. Each membership event identifies the administrator that made the change. The provider has no hook callbacks, market authority, token functions, or list of attached hooks.
+
+Provider administration uses its own two-step transfer. The pending administrator has no authority before acceptance. Acceptance changes only the provider administrator; the provider address, membership, and every hook attachment stay unchanged. There is no ArchController or Foundation registration check for providers or their administrators.
+
+`AccessListRoleProviderFactory` can deploy a provider directly or through the hook's generic `createRoleProvider` helper. Generic factory calldata is `abi.encode(AccessListRoleProviderFactoryInputs)`, where the struct contains `administrator`, `initialMembers`, and `salt`. The intended administrator is explicit because the factory caller may be a hook rather than the borrower. CREATE2 salts are namespaced by the caller, and the factory keeps no authority over the provider after deployment.
+
+The provider returns the current block timestamp for a listed account and zero for an unlisted account. It does not store a credential timestamp because membership remains valid until the administrator removes it.
+
+### TTL and removal behavior
+
+TTL `0` on a pull provider means no cache. The hook queries the provider on every credential-gated interaction, including another interaction in the same block. Removing an access-list member therefore affects the next gated check immediately.
+
+A positive TTL is an explicit cache window. If a hook queried the provider at timestamp `T`, the cached credential remains valid through `T + TTL`; membership removal takes effect for that hook after the cached credential expires. Different hooks may have different cache windows for the same provider.
+
+Push providers keep the existing timestamp behavior. A push credential with TTL `0` is usable at its grant timestamp but cannot be refreshed by the hook.
+
 ## tryValidateAccess(address lender, bytes hooksData)
 
 When a restricted function is called, the access control contract will attempt to validate the caller's access to the market in several ways.
 
-1. If lender has an unexpired credential from a provider that is still supported, return true.
+1. If the lender has a cacheable, unexpired credential from a provider that is still supported, return true. A pull credential with TTL `0` is never cacheable.
 2. If the lender provided `hooksData`, run [`handleHooksData(lender, hooksData)`](#handleHooksDataaddress-lender-bytes-hooksData)
     - If it returns a valid credential, go to step 5
 3. If the lender has an expired credential from a pull provider that is still supported, try to refresh their credential with `getCredential` (see: [tryPullCredential](#tryPullCredentialaddress-provider-address-lender))

--- a/docs/hooks/templates/Access Control Hooks.md
+++ b/docs/hooks/templates/Access Control Hooks.md
@@ -6,6 +6,14 @@ Hook administration does not confer credential authority. A new hook does not ad
 
 The hook administrator configures each provider with a TTL, which controls how long the hook may use a credential without consulting the provider again.
 
+## Hook administration
+
+Factory-created access-control hooks expose `administrator()` and `pendingAdministrator()`. The current administrator may request a transfer to another ArchController-registered principal, replace a pending request, or cancel it. The target must still be registered when it accepts.
+
+The pending administrator has no authority before acceptance. Only the pending address may accept. Acceptance changes the hook administrator and updates the creating factory's administrator index in the same transaction; if the factory callback fails, the entire acceptance reverts. The factory records the result but cannot initiate the transfer or reassign the hook on its own.
+
+Hook transfer changes who may configure provider attachments, TTLs, hook-local blocks, and hooked-market policy. It does not transfer a market, rewrite lender status, change provider membership or administration, or move the hook merely because one of its markets changes borrowers. The compatibility getter `borrower()` returns the current hook administrator.
+
 A role provider can be a push provider, a pull provider, or a validation provider depending on what it supports.
 All approved role providers can push credentials by calling `grantRole` or `grantRoles`.
 A provider is treated as a pull provider only if it successfully implements `isPullProvider()` and returns true, meaning the hooks contract can query it with `getCredential` to check if a lender has a credential using only the lender's address.
@@ -37,13 +45,13 @@ Role-provider administration is optional and separate from hook administration. 
 
 ## Access-list role provider
 
-`AccessListRoleProvider` is the managed pull provider included with v2.5. One instance owns one reusable address list, and the same instance can be attached to several hooks. A borrower can deploy separate instances when two markets should not share a list.
+`AccessListRoleProvider` is the managed pull provider included with v2.5. One instance is one reusable address list, and the same instance can be attached to several hooks. Use separate instances when two sets of hooks should not share a list.
 
-The current provider administrator may add or remove one member or an explicitly supplied batch. Members are enumerable, but removal uses swap-and-pop, so enumeration order is not stable. Each membership event identifies the administrator that made the change. The provider has no hook callbacks, market authority, token functions, or list of attached hooks.
+The current provider administrator may add or remove one member or an explicitly supplied batch. Members are enumerable, but removal uses swap-and-pop, so enumeration order is not stable. Each membership event records the provider's current administrator. The factory deployment event separately records the actual factory caller and the full initial member list. The provider has no hook callbacks, market authority, token functions, or list of attached hooks.
 
 Provider administration uses its own two-step transfer. The pending administrator has no authority before acceptance. Acceptance changes only the provider administrator; the provider address, membership, and every hook attachment stay unchanged. There is no ArchController or Foundation registration check for providers or their administrators.
 
-`AccessListRoleProviderFactory` can deploy a provider directly or through the hook's generic `createRoleProvider` helper. Generic factory calldata is `abi.encode(AccessListRoleProviderFactoryInputs)`, where the struct contains `administrator`, `initialMembers`, and `salt`. The intended administrator is explicit because the factory caller may be a hook rather than the borrower. CREATE2 salts are namespaced by the caller, and the factory keeps no authority over the provider after deployment.
+`AccessListRoleProviderFactory` can deploy a provider directly or through the hook's generic `createRoleProvider` helper. Generic factory calldata is `abi.encode(AccessListRoleProviderFactoryInputs)`, where the struct contains `administrator`, `initialMembers`, and `salt`. The intended administrator is explicit because the factory caller may be a hook rather than the provider administrator. CREATE2 salts are namespaced by the caller, and the factory keeps no authority over the provider after deployment.
 
 The provider returns the current block timestamp for a listed account and zero for an unlisted account. It does not store a credential timestamp because membership remains valid until the administrator removes it.
 
@@ -72,7 +80,7 @@ When a restricted function is called, the access control contract will attempt t
 
 ```mermaid
 flowchart TD
-    validateAccess[["tryValidateAccess(address lender, bytes hooksData)"]] --> hasUnexpiredCredential{Lender has\nunexpired credential?}
+    validateAccess[["tryValidateAccess(address lender, bytes hooksData)"]] --> hasUnexpiredCredential{Lender has cacheable\nunexpired credential?}
     hasUnexpiredCredential -- yes --> returnTrue([Access verified])
     hasUnexpiredCredential -- no --> providedHooksData{hooksData?}
     providedHooksData -- yes --> callHandleHooksData[["handleHooksData(lender, hooksData)"]]

--- a/docs/v2.5-audit-delta.md
+++ b/docs/v2.5-audit-delta.md
@@ -73,11 +73,17 @@ Post-review additions (rounding-interaction fixes, staged):
 
 - `src/access/IRoleProvider.sol`: [comment/style] `getCredential` documentation only.
 
+- `src/access/BaseAccessControls.sol`, `src/access/IHooksAdministrator.sol`, and the three access-control hook templates: [behavioral/interface] replace the immutable borrower/provider shortcut with explicit hook administration; remove the automatic administrator-as-push-provider entry; add two-step administrator transfer with acceptance-time ArchController registration checks; preserve provider, lender, block, known-lender, and hooked-market state; and treat TTL-zero pull credentials as non-cacheable.
+
+- `src/access/AccessListRoleProvider.sol`, `src/access/AccessListRoleProviderFactory.sol`, `src/access/IAccessListRoleProvider.sol`, `src/access/IAccessListRoleProviderFactory.sol`, and `src/access/IManagedRoleProvider.sol`: [new-code] add an enumerable reusable address-list pull provider, independent two-step provider administration, caller-namespaced deterministic deployment, explicit initial-administrator assignment, provider creation and membership events, and an authority-free factory.
+
 - `src/access/MarketConstraintHooks.sol`: [comment/style] doc correction around constraint behavior.
 
 - `src/access/ProviderStructs.sol`: [comment/style] role-provider input comment wording only.
 
 - `src/HooksFactory.sol`: [behavioral] paginated getters now return an empty array for boundary-empty pages after clamping; [behavioral] market deployment now verifies `create2WithStoredInitCode` returned the predicted market address and can revert `MarketDeploymentAddressMismatch`; [behavioral] `pushProtocolFeeBipsUpdates` now clamps end, reverts `InvalidPaginationRange` on `start > end`, and no-ops on `start == end`; [behavioral] the factory stores the borrower identity registry and threads direct deployments through as `borrower == borrowerPrincipal`. Log rationale: HooksFactory hardening, CR-06 pagination cleanup, and borrower identity.
+
+- `src/HooksFactory.sol` and `src/HooksFactoryRevolving.sol`: [behavioral/interface] hook-instance associations now follow explicit hook-administrator acceptance through a callback authenticated against the hook's creating factory. Removal uses swap-and-pop, moved indexes are repaired, deployment nonces remain monotonic, and neither factory operator can reassign a hook independently.
 
 - `src/IHooksFactory.sol`: [behavioral/interface] declares `MarketDeploymentAddressMismatch` and `InvalidPaginationRange`; [comment/style] clarifies pagination `end`, `onCreateMarket`, and fee-push docs. Log rationale: hardening, ambiguous `len`, style/stale cleanup.
 

--- a/docs/v2.5-audit-delta.md
+++ b/docs/v2.5-audit-delta.md
@@ -1,8 +1,8 @@
 # v2.5 Consolidated Pre-Audit Delta
 
-Baseline: branch `main` (the deployed, audited v2 protocol).
-Candidate: `feat/v2.5-remaining-features` at `7b32b8b`.
-Scope: `git diff main...7b32b8b -- src/` — 53 files, 4,918 insertions and 357 deletions over 112 commits.
+Baseline: branch `main` at `c7be403` (the deployed, audited v2 protocol).
+Candidate source snapshot: `feat/v2.5-hooks-role-providers` at `822045f`.
+Scope: `git diff c7be403...822045f -- src/` - 59 files, 5,856 insertions and 425 deletions over 116 commits.
 
 This document consolidates three independent review streams run over the full
 delta as a single artifact: two per-subsystem correctness reviews (codex), one
@@ -13,7 +13,7 @@ evidence backs the current state.
 
 ## 1. Executive summary
 
-- Four release areas: **revolving credit markets** (WildcatMarketRevolving + HooksFactoryRevolving), **periodic-term hooks** (recurring withdrawal windows + proposed/permissionless APR reductions), a **lens rework** (facade + helper contracts, with a v2.5 ABI that includes the periodic pending-APR-reduction execution flag), and **borrower identity and transfer** (operational borrower/principal separation, account registry, two-step market transfer, principal-aware sanctions, and transfer-aware wrapper authority).
+- Five release areas: **revolving credit markets** (WildcatMarketRevolving + HooksFactoryRevolving), **periodic-term hooks** (recurring withdrawal windows + proposed/permissionless APR reductions), a **lens rework** (facade + helper contracts, with a v2.5 ABI that includes the periodic pending-APR-reduction execution flag), **borrower identity and transfer** (operational borrower/principal separation, account registry, two-step market transfer, principal-aware sanctions, and transfer-aware wrapper authority), and **hook/provider authority separation** (transferable hook administration, reusable access-list providers, and explicit pull-credential cache policy).
 - One deliberate hardening with protocol-wide reach: transfer/deposit/
   withdrawal scaling changed from half-up (`rayDiv`/`scaleAmount`) to
   **floor** (`scaleAmountDown`). Every regression found in this review
@@ -27,7 +27,7 @@ evidence backs the current state.
 - The 4626 wrapper was rebuilt for floor-rounding markets and its factory is
   now a generation-routing facade; covered by its own review cycle and the
   EIP-4626 audit-scope note.
-- The borrower-transfer feature series is implemented and has passed the full test suite and deploy-profile size checks. The prior coverage appendix predates this feature series and must be refreshed before the final audit handoff.
+- The borrower-transfer and hook/provider feature series are implemented and have passed the full test suite and deploy-profile size checks. The prior coverage appendix predates both feature series and must be refreshed before the final audit handoff.
 
 ## 2. Change inventory
 
@@ -75,7 +75,7 @@ Post-review additions (rounding-interaction fixes, staged):
 
 - `src/access/BaseAccessControls.sol`, `src/access/IHooksAdministrator.sol`, and the three access-control hook templates: [behavioral/interface] replace the immutable borrower/provider shortcut with explicit hook administration; remove the automatic administrator-as-push-provider entry; add two-step administrator transfer with acceptance-time ArchController registration checks; preserve provider, lender, block, known-lender, and hooked-market state; and treat TTL-zero pull credentials as non-cacheable.
 
-- `src/access/AccessListRoleProvider.sol`, `src/access/AccessListRoleProviderFactory.sol`, `src/access/IAccessListRoleProvider.sol`, `src/access/IAccessListRoleProviderFactory.sol`, and `src/access/IManagedRoleProvider.sol`: [new-code] add an enumerable reusable address-list pull provider, independent two-step provider administration, caller-namespaced deterministic deployment, explicit initial-administrator assignment, provider creation and membership events, and an authority-free factory.
+- `src/access/AccessListRoleProvider.sol`, `src/access/AccessListRoleProviderFactory.sol`, `src/access/IAccessListRoleProvider.sol`, `src/access/IAccessListRoleProviderFactory.sol`, and `src/access/IManagedRoleProvider.sol`: [new-code] add an enumerable reusable address-list pull provider, independent two-step provider administration, caller-namespaced deterministic deployment, explicit initial-administrator assignment, provider creation and membership events, and a factory that retains no authority.
 
 - `src/access/MarketConstraintHooks.sol`: [comment/style] doc correction around constraint behavior.
 
@@ -183,18 +183,23 @@ implementations; version-string consumers (`'2.5'` keeps the first-byte
 8. Market borrower authority is a storage-backed two-step transfer rather than an immutable deployment identity. Pending status grants no authority, acceptance revalidates identity, registration, and raw sanctions state, and transfer is available in active, delinquent, and closed markets.
 9. Markets record operational borrower separately from registered principal. Approved account factories register each account once through the new identity registry. Account principals may transfer their association through a two-step path, while each market continues using its stored accepted identity until that market explicitly accepts the new principal.
 10. Lender-facing sanctions checks use the market principal, raw borrower/principal checks gate draws and transfers, and wrapper authority follows live market identity. Hooks and providers do not move implicitly with a market transfer.
+11. Hook administration is a separate two-step authority. The target must be an ArchController-registered principal at request and acceptance, the pending administrator has no authority, and the creating factory's association index updates atomically with acceptance.
+12. A hook administrator is no longer installed as a permanent push provider. Hook transfer preserves provider attachments, lender state, hook-local blocks, known-lender state, and hooked-market configuration.
+13. `AccessListRoleProvider` provides a reusable address list with independent two-step administration. TTL zero makes a pull credential non-cacheable, including within the same block; a positive TTL deliberately accepts delayed removal until the cache window expires.
 
 ## 5. Evidence
 
-- Current full suite after the borrower-account principal-transfer correction: 65 suites, 1,423 tests, 0 failures, 0 skipped.
+- Full suite at candidate source snapshot `822045f`: 1,518 tests passed.
 - Borrower-identity registry coverage includes principal-transfer request, replacement, cancellation, acceptance, authority handoff, factory removal, current-principal removal, target revalidation, and current-principal enumeration.
 - Borrower-transfer coverage includes direct and account identities, same-principal rotation, principal migration, request replacement/cancellation, acceptance-time registration and sanctions changes, active/delinquent/closed accounting snapshots, revolving drawn-amount preservation, wrapper authority, sanctions namespaces, and v2.5 lens output.
-- Deploy-profile runtime sizes after the borrower-account principal-transfer correction: `WildcatMarket` 22,534 bytes, `WildcatMarketRevolving` 23,142 bytes, `MarketLensCore` 19,814 bytes, `MarketLensAggregator` 20,415 bytes, and `WildcatBorrowerIdentityRegistry` 5,172 bytes. All remain below the 24,576-byte EIP-170 limit.
+- Hook-administrator coverage includes request replacement, cancellation, pending-authority denial, acceptance-time registration, callback rollback, state preservation, factory callback authentication, swap-and-pop index repair, monotonic deployment nonces, and standard/revolving parity.
+- Access-list coverage includes isolated and shared provider instances, membership and pagination, batch rollback, provider transfer, deterministic factory deployment, caller-scoped salts, zero-TTL same-block removal, positive-TTL delayed removal, and hook-local block preservation.
+- Deploy-profile runtime sizes include `WildcatMarket` at 22,534 bytes, `WildcatMarketRevolving` at 23,142 bytes, `HooksFactory` at 15,372 bytes, `HooksFactoryRevolving` at 16,424 bytes, `AccessListRoleProvider` at 2,898 bytes, and `AccessListRoleProviderFactory` at 4,736 bytes. All remain below the 24,576-byte EIP-170 limit.
 - Stateful fuzz: matrix invariants 18/18 at 10,000 runs x depth 100
   (pre-fix baseline) and at 5,000 x 100 with zero stranding tolerance
   (post-fix); CAF12 invariants 8/8 at 10,000 x 100; full suite at 10,000
   fuzz runs, 0 counterexamples.
-- The most recent coverage run predates the borrower-transfer feature. Its historical result and uncovered-branch inventory remain below, but they are not current coverage evidence for the new registry or transfer paths. The final coverage run still requires the documented SphereX workaround.
+- The most recent coverage run predates the borrower-transfer and hook/provider features. Its historical result and uncovered-branch inventory remain below, but they are not current coverage evidence for the new registry, transfer, hook-administration, or access-list paths. The final coverage run still requires the documented SphereX workaround.
 - Arithmetic proofs: 10/10 items proven for the F1/F2 fixes (exact-integer
   search, edge sweeps at sf = RAY, uint112.max, 1-wei amounts, uint104
   boundaries).
@@ -203,7 +208,7 @@ implementations; version-string consumers (`'2.5'` keeps the first-byte
 
 ## 6. Pre-transfer coverage appendix: enumerated uncovered branches
 
-The previous checkpoint measured **98.35% lines, 96.32% branches** (498/517) over `src/` with 1,298 tests. It predates the borrower-transfer feature and must not be presented as final coverage for the current candidate. At that checkpoint, every uncovered branch was enumerated and justified below. Categories: **[D]** deployment-time only,
+The previous checkpoint measured **98.35% lines, 96.32% branches** (498/517) over `src/` with 1,298 tests. It predates the borrower-transfer and hook/provider features and must not be presented as final coverage for the current candidate. At that checkpoint, every uncovered branch was enumerated and justified below. Categories: **[D]** deployment-time only,
 **[P]** proven unreachable (arithmetic identity or dominating guard),
 **[E]** external-dependency revert-side (documented in Known Issues),
 **[U]** unused library-completeness overload, **[A]** instrumentation

--- a/src/HooksFactory.sol
+++ b/src/HooksFactory.sol
@@ -11,6 +11,7 @@ import './access/IHooks.sol';
 import './IHooksFactory.sol';
 import './types/TransientBytesArray.sol';
 import './spherex/SphereXProtectedRegisteredBase.sol';
+import './access/IHooksAdministrator.sol';
 import './interfaces/IBorrowerIdentityRegistry.sol';
 
 struct TmpMarketParameterStorage {
@@ -73,8 +74,22 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
 
   address[] internal _hooksTemplates;
 
-  /// @dev Mapping from borrower to their deployed hooks instances
-  mapping(address borrower => address[] hooksInstances) internal _hooksInstancesByBorrower;
+  /// @dev Hooks instances currently administered by each address.
+  mapping(address administrator => address[] hooksInstances)
+    internal _hooksInstancesByAdministrator;
+
+  /// @dev Current administrator for each hooks instance deployed by this factory.
+  mapping(address hooksInstance => address administrator)
+    public
+    override getHooksAdministrator;
+
+  /// @dev Position of each hooks instance in its administrator's array.
+  mapping(address hooksInstance => uint256 index) internal _hooksInstanceIndex;
+
+  /// @dev Monotonic deployment nonce used in hook CREATE2 salts.
+  mapping(address administrator => uint256 nonce)
+    public
+    override getHooksInstanceDeploymentNonce;
 
   /**
    * @dev Mapping from hooks template to markets created with it.
@@ -358,20 +373,97 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
     address hooksTemplate,
     bytes calldata constructorArgs
   ) external override nonReentrant returns (address hooksInstance) {
-    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
-    hooksInstance = _deployHooksInstance(borrowerPrincipal, hooksTemplate, constructorArgs);
+    address administrator = _resolveBorrowerPrincipal(msg.sender);
+    hooksInstance = _deployHooksInstance(administrator, hooksTemplate, constructorArgs);
+  }
+
+  function getHooksInstancesForAdministrator(
+    address administrator
+  ) external view override returns (address[] memory) {
+    return _hooksInstancesByAdministrator[administrator];
+  }
+
+  function getHooksInstancesForAdministrator(
+    address administrator,
+    uint256 start,
+    uint256 end
+  ) external view override returns (address[] memory arr) {
+    address[] storage hooksInstances = _hooksInstancesByAdministrator[administrator];
+    end = MathUtils.min(end, hooksInstances.length);
+    if (start >= end) return new address[](0);
+    uint256 count = end - start;
+    arr = new address[](count);
+    for (uint256 i = 0; i < count; i++) {
+      arr[i] = hooksInstances[start + i];
+    }
+  }
+
+  function getHooksInstancesCountForAdministrator(
+    address administrator
+  ) external view override returns (uint256) {
+    return _hooksInstancesByAdministrator[administrator].length;
   }
 
   function getHooksInstancesForBorrower(
     address borrower
   ) external view override returns (address[] memory) {
-    return _hooksInstancesByBorrower[borrower];
+    return _hooksInstancesByAdministrator[borrower];
   }
 
   function getHooksInstancesCountForBorrower(
     address borrower
   ) external view override returns (uint256) {
-    return _hooksInstancesByBorrower[borrower].length;
+    return _hooksInstancesByAdministrator[borrower].length;
+  }
+
+  /**
+   * @dev Moves a hooks instance to its new administrator's array. Removal uses
+   *      swap-and-pop, so an administrator's enumeration is not ordered.
+   */
+  function onHooksAdministratorTransferred(
+    address previousAdministrator,
+    address newAdministrator
+  ) external override nonReentrant {
+    address hooksInstance = msg.sender;
+    if (getHooksTemplateForInstance[hooksInstance] == address(0)) {
+      revert HooksInstanceNotFound();
+    }
+    if (
+      previousAdministrator == newAdministrator ||
+      newAdministrator == address(0) ||
+      getHooksAdministrator[hooksInstance] != previousAdministrator ||
+      IHooksAdministrator(hooksInstance).administrator() != newAdministrator ||
+      IHooksAdministrator(hooksInstance).pendingAdministrator() != address(0) ||
+      !IWildcatArchController(_archController).isRegisteredBorrower(newAdministrator)
+    ) {
+      revert InvalidHooksAdministrator();
+    }
+
+    address[] storage previousHooksInstances = _hooksInstancesByAdministrator[
+      previousAdministrator
+    ];
+    uint256 indexToRemove = _hooksInstanceIndex[hooksInstance];
+    uint256 previousCount = previousHooksInstances.length;
+    if (indexToRemove >= previousCount || previousHooksInstances[indexToRemove] != hooksInstance) {
+      revert InvalidHooksInstanceAssociation();
+    }
+    uint256 lastIndex = previousCount - 1;
+    if (indexToRemove != lastIndex) {
+      address movedHooksInstance = previousHooksInstances[lastIndex];
+      previousHooksInstances[indexToRemove] = movedHooksInstance;
+      _hooksInstanceIndex[movedHooksInstance] = indexToRemove;
+    }
+    previousHooksInstances.pop();
+
+    _hooksInstanceIndex[hooksInstance] = _hooksInstancesByAdministrator[newAdministrator].length;
+    _hooksInstancesByAdministrator[newAdministrator].push(hooksInstance);
+    getHooksAdministrator[hooksInstance] = newAdministrator;
+
+    emit HooksInstanceAdministratorTransferred(
+      hooksInstance,
+      previousAdministrator,
+      newAdministrator
+    );
   }
 
   function isHooksInstance(address hooksInstance) external view override returns (bool) {
@@ -379,7 +471,7 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
   }
 
   function _deployHooksInstance(
-    address borrowerPrincipal,
+    address administrator,
     address hooksTemplate,
     bytes calldata constructorArgs
   ) internal returns (address hooksInstance) {
@@ -391,17 +483,17 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
       revert HooksTemplateNotAvailable();
     }
 
-    uint256 numHooksForBorrower = _hooksInstancesByBorrower[borrowerPrincipal].length;
+    uint256 deploymentNonce = getHooksInstanceDeploymentNonce[administrator];
     bytes32 salt;
     assembly {
-      salt := or(shl(96, borrowerPrincipal), numHooksForBorrower)
+      salt := or(shl(96, administrator), deploymentNonce)
       let initCodePointer := mload(0x40)
       let initCodeSize := sub(extcodesize(hooksTemplate), 1)
       // Copy code from target address to memory starting at byte 1
       extcodecopy(hooksTemplate, initCodePointer, 1, initCodeSize)
       let endInitCodePointer := add(initCodePointer, initCodeSize)
-      // Write the borrower principal as the first parameter
-      mstore(endInitCodePointer, borrowerPrincipal)
+      // Write the administrator as the first parameter
+      mstore(endInitCodePointer, administrator)
       // Write the offset to the encoded constructor args
       mstore(add(endInitCodePointer, 0x20), 0x40)
       // Write the length of the encoded constructor args
@@ -418,9 +510,12 @@ contract HooksFactory is SphereXProtectedRegisteredBase, ReentrancyGuard, IHooks
         revert(0x1c, 0x04)
       }
     }
-    _hooksInstancesByBorrower[borrowerPrincipal].push(hooksInstance);
+    getHooksInstanceDeploymentNonce[administrator] = deploymentNonce + 1;
+    _hooksInstanceIndex[hooksInstance] = _hooksInstancesByAdministrator[administrator].length;
+    _hooksInstancesByAdministrator[administrator].push(hooksInstance);
+    getHooksAdministrator[hooksInstance] = administrator;
 
-    emit HooksInstanceDeployed(hooksInstance, hooksTemplate);
+    emit HooksInstanceDeployed(hooksInstance, hooksTemplate, administrator);
     getHooksTemplateForInstance[hooksInstance] = hooksTemplate;
   }
 

--- a/src/HooksFactoryRevolving.sol
+++ b/src/HooksFactoryRevolving.sol
@@ -11,6 +11,7 @@ import './access/IHooks.sol';
 import './IHooksFactoryRevolving.sol';
 import './types/TransientBytesArray.sol';
 import './spherex/SphereXProtectedRegisteredBase.sol';
+import './access/IHooksAdministrator.sol';
 import './interfaces/IBorrowerIdentityRegistry.sol';
 
 struct TmpRevolvingMarketParameterStorage {
@@ -91,8 +92,22 @@ contract HooksFactoryRevolving is
 
   address[] internal _hooksTemplates;
 
-  /// @dev Mapping from borrower to their deployed hooks instances
-  mapping(address borrower => address[] hooksInstances) internal _hooksInstancesByBorrower;
+  /// @dev Hooks instances currently administered by each address.
+  mapping(address administrator => address[] hooksInstances)
+    internal _hooksInstancesByAdministrator;
+
+  /// @dev Current administrator for each hooks instance deployed by this factory.
+  mapping(address hooksInstance => address administrator)
+    public
+    override getHooksAdministrator;
+
+  /// @dev Position of each hooks instance in its administrator's array.
+  mapping(address hooksInstance => uint256 index) internal _hooksInstanceIndex;
+
+  /// @dev Monotonic deployment nonce used in hook CREATE2 salts.
+  mapping(address administrator => uint256 nonce)
+    public
+    override getHooksInstanceDeploymentNonce;
 
   /**
    * @dev Mapping from hooks template to markets created with it.
@@ -386,20 +401,97 @@ contract HooksFactoryRevolving is
     address hooksTemplate,
     bytes calldata constructorArgs
   ) external override nonReentrant returns (address hooksInstance) {
-    address borrowerPrincipal = _resolveBorrowerPrincipal(msg.sender);
-    hooksInstance = _deployHooksInstance(borrowerPrincipal, hooksTemplate, constructorArgs);
+    address administrator = _resolveBorrowerPrincipal(msg.sender);
+    hooksInstance = _deployHooksInstance(administrator, hooksTemplate, constructorArgs);
+  }
+
+  function getHooksInstancesForAdministrator(
+    address administrator
+  ) external view override returns (address[] memory) {
+    return _hooksInstancesByAdministrator[administrator];
+  }
+
+  function getHooksInstancesForAdministrator(
+    address administrator,
+    uint256 start,
+    uint256 end
+  ) external view override returns (address[] memory arr) {
+    address[] storage hooksInstances = _hooksInstancesByAdministrator[administrator];
+    end = MathUtils.min(end, hooksInstances.length);
+    if (start >= end) return new address[](0);
+    uint256 count = end - start;
+    arr = new address[](count);
+    for (uint256 i = 0; i < count; i++) {
+      arr[i] = hooksInstances[start + i];
+    }
+  }
+
+  function getHooksInstancesCountForAdministrator(
+    address administrator
+  ) external view override returns (uint256) {
+    return _hooksInstancesByAdministrator[administrator].length;
   }
 
   function getHooksInstancesForBorrower(
     address borrower
   ) external view override returns (address[] memory) {
-    return _hooksInstancesByBorrower[borrower];
+    return _hooksInstancesByAdministrator[borrower];
   }
 
   function getHooksInstancesCountForBorrower(
     address borrower
   ) external view override returns (uint256) {
-    return _hooksInstancesByBorrower[borrower].length;
+    return _hooksInstancesByAdministrator[borrower].length;
+  }
+
+  /**
+   * @dev Moves a hooks instance to its new administrator's array. Removal uses
+   *      swap-and-pop, so an administrator's enumeration is not ordered.
+   */
+  function onHooksAdministratorTransferred(
+    address previousAdministrator,
+    address newAdministrator
+  ) external override nonReentrant {
+    address hooksInstance = msg.sender;
+    if (getHooksTemplateForInstance[hooksInstance] == address(0)) {
+      revert HooksInstanceNotFound();
+    }
+    if (
+      previousAdministrator == newAdministrator ||
+      newAdministrator == address(0) ||
+      getHooksAdministrator[hooksInstance] != previousAdministrator ||
+      IHooksAdministrator(hooksInstance).administrator() != newAdministrator ||
+      IHooksAdministrator(hooksInstance).pendingAdministrator() != address(0) ||
+      !IWildcatArchController(_archController).isRegisteredBorrower(newAdministrator)
+    ) {
+      revert InvalidHooksAdministrator();
+    }
+
+    address[] storage previousHooksInstances = _hooksInstancesByAdministrator[
+      previousAdministrator
+    ];
+    uint256 indexToRemove = _hooksInstanceIndex[hooksInstance];
+    uint256 previousCount = previousHooksInstances.length;
+    if (indexToRemove >= previousCount || previousHooksInstances[indexToRemove] != hooksInstance) {
+      revert InvalidHooksInstanceAssociation();
+    }
+    uint256 lastIndex = previousCount - 1;
+    if (indexToRemove != lastIndex) {
+      address movedHooksInstance = previousHooksInstances[lastIndex];
+      previousHooksInstances[indexToRemove] = movedHooksInstance;
+      _hooksInstanceIndex[movedHooksInstance] = indexToRemove;
+    }
+    previousHooksInstances.pop();
+
+    _hooksInstanceIndex[hooksInstance] = _hooksInstancesByAdministrator[newAdministrator].length;
+    _hooksInstancesByAdministrator[newAdministrator].push(hooksInstance);
+    getHooksAdministrator[hooksInstance] = newAdministrator;
+
+    emit HooksInstanceAdministratorTransferred(
+      hooksInstance,
+      previousAdministrator,
+      newAdministrator
+    );
   }
 
   function isHooksInstance(address hooksInstance) external view override returns (bool) {
@@ -407,7 +499,7 @@ contract HooksFactoryRevolving is
   }
 
   function _deployHooksInstance(
-    address borrowerPrincipal,
+    address administrator,
     address hooksTemplate,
     bytes calldata constructorArgs
   ) internal returns (address hooksInstance) {
@@ -419,17 +511,17 @@ contract HooksFactoryRevolving is
       revert HooksTemplateNotAvailable();
     }
 
-    uint256 numHooksForBorrower = _hooksInstancesByBorrower[borrowerPrincipal].length;
+    uint256 deploymentNonce = getHooksInstanceDeploymentNonce[administrator];
     bytes32 salt;
     assembly {
-      salt := or(shl(96, borrowerPrincipal), numHooksForBorrower)
+      salt := or(shl(96, administrator), deploymentNonce)
       let initCodePointer := mload(0x40)
       let initCodeSize := sub(extcodesize(hooksTemplate), 1)
       // Copy code from target address to memory starting at byte 1
       extcodecopy(hooksTemplate, initCodePointer, 1, initCodeSize)
       let endInitCodePointer := add(initCodePointer, initCodeSize)
-      // Write the borrower principal as the first parameter
-      mstore(endInitCodePointer, borrowerPrincipal)
+      // Write the administrator as the first parameter
+      mstore(endInitCodePointer, administrator)
       // Write the offset to the encoded constructor args
       mstore(add(endInitCodePointer, 0x20), 0x40)
       // Write the length of the encoded constructor args
@@ -446,9 +538,12 @@ contract HooksFactoryRevolving is
         revert(0x1c, 0x04)
       }
     }
-    _hooksInstancesByBorrower[borrowerPrincipal].push(hooksInstance);
+    getHooksInstanceDeploymentNonce[administrator] = deploymentNonce + 1;
+    _hooksInstanceIndex[hooksInstance] = _hooksInstancesByAdministrator[administrator].length;
+    _hooksInstancesByAdministrator[administrator].push(hooksInstance);
+    getHooksAdministrator[hooksInstance] = administrator;
 
-    emit HooksInstanceDeployed(hooksInstance, hooksTemplate);
+    emit HooksInstanceDeployed(hooksInstance, hooksTemplate, administrator);
     getHooksTemplateForInstance[hooksInstance] = hooksTemplate;
   }
 

--- a/src/IHooksFactory.sol
+++ b/src/IHooksFactory.sol
@@ -43,8 +43,19 @@ interface IHooksFactoryEventsAndErrors {
   error AssetBlacklisted();
   error SetProtocolFeeBipsFailed();
   error InvalidPaginationRange();
+  error InvalidHooksAdministrator();
+  error InvalidHooksInstanceAssociation();
 
-  event HooksInstanceDeployed(address hooksInstance, address hooksTemplate);
+  event HooksInstanceDeployed(
+    address indexed hooksInstance,
+    address indexed hooksTemplate,
+    address indexed administrator
+  );
+  event HooksInstanceAdministratorTransferred(
+    address indexed hooksInstance,
+    address indexed previousAdministrator,
+    address indexed newAdministrator
+  );
   event HooksTemplateAdded(
     address hooksTemplate,
     string name,
@@ -201,10 +212,35 @@ interface IHooksFactory is IHooksFactoryEventsAndErrors {
     bytes calldata constructorArgs
   ) external returns (address hooksDeployment);
 
-  /// @dev Hooks deployed under a direct principal or registered account are indexed by principal.
+  function getHooksAdministrator(address hooks) external view returns (address);
+
+  function getHooksInstanceDeploymentNonce(address administrator) external view returns (uint256);
+
+  function getHooksInstancesForAdministrator(
+    address administrator
+  ) external view returns (address[] memory);
+
+  function getHooksInstancesForAdministrator(
+    address administrator,
+    uint256 start,
+    uint256 end
+  ) external view returns (address[] memory);
+
+  function getHooksInstancesCountForAdministrator(
+    address administrator
+  ) external view returns (uint256);
+
+  /// @dev Compatibility alias for `getHooksInstancesForAdministrator`.
   function getHooksInstancesForBorrower(address borrower) external view returns (address[] memory);
 
+  /// @dev Compatibility alias for `getHooksInstancesCountForAdministrator`.
   function getHooksInstancesCountForBorrower(address borrower) external view returns (uint256);
+
+  /// @dev Called by a hooks instance after accepting a two-step administrator transfer.
+  function onHooksAdministratorTransferred(
+    address previousAdministrator,
+    address newAdministrator
+  ) external;
 
   /// @dev Check if a hooks instance was deployed by the factory.
   function isHooksInstance(address hooks) external view returns (bool);

--- a/src/IHooksFactoryRevolving.sol
+++ b/src/IHooksFactoryRevolving.sol
@@ -131,10 +131,35 @@ interface IHooksFactoryRevolving is IHooksFactoryEventsAndErrors {
     bytes calldata constructorArgs
   ) external returns (address hooksDeployment);
 
-  /// @dev Hooks deployed under a direct principal or registered account are indexed by principal.
+  function getHooksAdministrator(address hooks) external view returns (address);
+
+  function getHooksInstanceDeploymentNonce(address administrator) external view returns (uint256);
+
+  function getHooksInstancesForAdministrator(
+    address administrator
+  ) external view returns (address[] memory);
+
+  function getHooksInstancesForAdministrator(
+    address administrator,
+    uint256 start,
+    uint256 end
+  ) external view returns (address[] memory);
+
+  function getHooksInstancesCountForAdministrator(
+    address administrator
+  ) external view returns (uint256);
+
+  /// @dev Compatibility alias for `getHooksInstancesForAdministrator`.
   function getHooksInstancesForBorrower(address borrower) external view returns (address[] memory);
 
+  /// @dev Compatibility alias for `getHooksInstancesCountForAdministrator`.
   function getHooksInstancesCountForBorrower(address borrower) external view returns (uint256);
+
+  /// @dev Called by a hooks instance after accepting a two-step administrator transfer.
+  function onHooksAdministratorTransferred(
+    address previousAdministrator,
+    address newAdministrator
+  ) external;
 
   /// @dev Check if a hooks instance was deployed by the factory.
   function isHooksInstance(address hooks) external view returns (bool);

--- a/src/access/AccessListRoleProvider.sol
+++ b/src/access/AccessListRoleProvider.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
+pragma solidity ^0.8.20;
+
+import { EnumerableSet } from 'openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+import '../libraries/SafeCastLib.sol';
+import './IAccessListRoleProvider.sol';
+
+using SafeCastLib for uint256;
+
+/**
+ * @dev Pull-based role provider for one reusable address list. The provider owns
+ *      membership. Hooks decide whether to trust it and how long to cache its answers.
+ */
+contract AccessListRoleProvider is IAccessListRoleProvider {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  bool public constant override isPullProvider = true;
+
+  address public override administrator;
+  address public override pendingAdministrator;
+
+  EnumerableSet.AddressSet internal _members;
+
+  modifier onlyAdministrator() {
+    if (msg.sender != administrator) revert CallerNotAdministrator();
+    _;
+  }
+
+  constructor(address administrator_, address[] memory initialMembers) {
+    if (administrator_ == address(0)) revert InvalidAdministratorTransferTarget();
+    administrator = administrator_;
+    _addMembers(initialMembers);
+  }
+
+  // ========================================================================== //
+  //                         Administrator transfer                             //
+  // ========================================================================== //
+
+  function requestAdministratorTransfer(
+    address newAdministrator
+  ) external override onlyAdministrator {
+    if (newAdministrator == address(0) || newAdministrator == administrator) {
+      revert InvalidAdministratorTransferTarget();
+    }
+    address previousPendingAdministrator = pendingAdministrator;
+    pendingAdministrator = newAdministrator;
+    emit AdministratorTransferRequested(
+      msg.sender,
+      previousPendingAdministrator,
+      newAdministrator
+    );
+  }
+
+  function cancelAdministratorTransfer() external override onlyAdministrator {
+    address cancelledPendingAdministrator = pendingAdministrator;
+    if (cancelledPendingAdministrator == address(0)) {
+      revert NoPendingAdministratorTransfer();
+    }
+    pendingAdministrator = address(0);
+    emit AdministratorTransferCancelled(msg.sender, cancelledPendingAdministrator);
+  }
+
+  function acceptAdministratorTransfer() external override {
+    address newAdministrator = pendingAdministrator;
+    if (msg.sender != newAdministrator) revert NotPendingAdministrator();
+
+    address previousAdministrator = administrator;
+    pendingAdministrator = address(0);
+    administrator = newAdministrator;
+    emit AdministratorTransferred(previousAdministrator, newAdministrator);
+  }
+
+  // ========================================================================== //
+  //                              Member updates                                //
+  // ========================================================================== //
+
+  function addMember(address account) external override onlyAdministrator {
+    _addMember(account);
+  }
+
+  function addMembers(address[] calldata accounts) external override onlyAdministrator {
+    _addMembers(accounts);
+  }
+
+  function _addMembers(address[] memory accounts) internal {
+    for (uint256 i; i < accounts.length; i++) {
+      _addMember(accounts[i]);
+    }
+  }
+
+  function _addMember(address account) internal {
+    if (account == address(0)) revert InvalidMember();
+    if (!_members.add(account)) revert MemberAlreadyExists();
+    emit MemberAdded(administrator, account);
+  }
+
+  function removeMember(address account) external override onlyAdministrator {
+    _removeMember(account);
+  }
+
+  function removeMembers(address[] calldata accounts) external override onlyAdministrator {
+    for (uint256 i; i < accounts.length; i++) {
+      _removeMember(accounts[i]);
+    }
+  }
+
+  function _removeMember(address account) internal {
+    if (!_members.remove(account)) revert MemberNotFound();
+    emit MemberRemoved(administrator, account);
+  }
+
+  // ========================================================================== //
+  //                              Member queries                                //
+  // ========================================================================== //
+
+  function isMember(address account) external view override returns (bool) {
+    return _members.contains(account);
+  }
+
+  function getMembers() external view override returns (address[] memory) {
+    return _members.values();
+  }
+
+  function getMembers(
+    uint256 start,
+    uint256 end
+  ) external view override returns (address[] memory members) {
+    if (start > end) revert InvalidPaginationRange();
+    uint256 length = _members.length();
+    if (end > length) end = length;
+    if (start >= end) return new address[](0);
+
+    members = new address[](end - start);
+    for (uint256 i; i < members.length; i++) {
+      members[i] = _members.at(start + i);
+    }
+  }
+
+  function getMembersCount() external view override returns (uint256) {
+    return _members.length();
+  }
+
+  // ========================================================================== //
+  //                            Credential queries                              //
+  // ========================================================================== //
+
+  function getCredential(
+    address account
+  ) external view override returns (uint32 credentialTimestamp) {
+    if (_members.contains(account)) credentialTimestamp = block.timestamp.toUint32();
+  }
+
+  function validateCredential(
+    address account,
+    bytes calldata
+  ) external view override returns (uint32 credentialTimestamp) {
+    if (_members.contains(account)) credentialTimestamp = block.timestamp.toUint32();
+  }
+}

--- a/src/access/AccessListRoleProviderFactory.sol
+++ b/src/access/AccessListRoleProviderFactory.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LicenseRef-Commons-Clause-1.0
+pragma solidity ^0.8.20;
+
+import './AccessListRoleProvider.sol';
+import './IAccessListRoleProviderFactory.sol';
+
+/**
+ * @dev Deploys access-list providers without retaining any authority over them.
+ *      Salts are namespaced by the caller so another caller cannot consume a
+ *      deployment address first.
+ */
+contract AccessListRoleProviderFactory is IAccessListRoleProviderFactory {
+  function createRoleProvider(
+    bytes calldata data
+  ) external override returns (address provider) {
+    AccessListRoleProviderFactoryInputs memory inputs = abi.decode(
+      data,
+      (AccessListRoleProviderFactoryInputs)
+    );
+    provider = _createRoleProvider(msg.sender, inputs);
+  }
+
+  function createAccessListRoleProvider(
+    AccessListRoleProviderFactoryInputs calldata inputs
+  ) external override returns (address provider) {
+    provider = _createRoleProvider(msg.sender, inputs);
+  }
+
+  function _createRoleProvider(
+    address deployer,
+    AccessListRoleProviderFactoryInputs memory inputs
+  ) internal returns (address provider) {
+    address expectedProvider = _computeRoleProviderAddress(deployer, inputs);
+    if (expectedProvider.code.length != 0) revert RoleProviderAlreadyExists();
+    bytes32 salt = _deriveSalt(deployer, inputs.salt);
+    provider = address(
+      new AccessListRoleProvider{ salt: salt }(inputs.administrator, inputs.initialMembers)
+    );
+    emit AccessListRoleProviderDeployed(
+      provider,
+      inputs.administrator,
+      deployer,
+      inputs.salt,
+      inputs.initialMembers
+    );
+  }
+
+  function computeRoleProviderAddress(
+    address deployer,
+    AccessListRoleProviderFactoryInputs calldata inputs
+  ) external view override returns (address provider) {
+    provider = _computeRoleProviderAddress(deployer, inputs);
+  }
+
+  function _computeRoleProviderAddress(
+    address deployer,
+    AccessListRoleProviderFactoryInputs memory inputs
+  ) internal view returns (address provider) {
+    bytes32 initCodeHash = keccak256(
+      abi.encodePacked(
+        type(AccessListRoleProvider).creationCode,
+        abi.encode(inputs.administrator, inputs.initialMembers)
+      )
+    );
+    provider = address(
+      uint160(
+        uint256(
+          keccak256(
+            abi.encodePacked(
+              bytes1(0xff),
+              address(this),
+              _deriveSalt(deployer, inputs.salt),
+              initCodeHash
+            )
+          )
+        )
+      )
+    );
+  }
+
+  function _deriveSalt(address deployer, bytes32 salt) internal pure returns (bytes32) {
+    return keccak256(abi.encode(deployer, salt));
+  }
+}

--- a/src/access/BaseAccessControls.sol
+++ b/src/access/BaseAccessControls.sol
@@ -421,9 +421,7 @@ contract BaseAccessControls is IHooksAdministrator {
     if (status.lastApprovalTimestamp > 0) {
       RoleProvider provider = _roleProviders[status.lastProvider];
       if (!provider.isNull()) {
-        // If credential is not expired and the provider is still
-        // supported, the lender has a valid credential.
-        if (status.credentialNotExpired(provider)) return status;
+        if (_canUseCachedCredential(status, provider)) return status;
 
         // If credential is expired but the provider is still supported and
         // allows refreshing (i.e. it's a pull provider), try to refresh.
@@ -623,6 +621,19 @@ contract BaseAccessControls is IHooksAdministrator {
     }
   }
 
+  /**
+   * @dev A zero-TTL pull provider is the source of truth on every check, including
+   *      another check in the same block. Push providers keep their existing
+   *      timestamp behavior because the hook cannot refresh them.
+   */
+  function _canUseCachedCredential(
+    LenderStatus memory status,
+    RoleProvider provider
+  ) internal view returns (bool) {
+    if (provider.isPullProvider() && provider.timeToLive() == 0) return false;
+    return status.credentialNotExpired(provider);
+  }
+
   function _readAddress(bytes calldata hooksData) internal pure returns (address providerAddress) {
     assembly {
       providerAddress := shr(96, calldataload(hooksData.offset))
@@ -793,8 +804,8 @@ contract BaseAccessControls is IHooksAdministrator {
       ? _roleProviders[status.lastProvider]
       : EmptyRoleProvider;
 
-    // If the lender has an active credential and the last provider is still supported, return
-    if (!lastProvider.isNull() && status.credentialNotExpired(lastProvider)) {
+    // If the lender has a cacheable active credential from a supported provider, return.
+    if (!lastProvider.isNull() && _canUseCachedCredential(status, lastProvider)) {
       return (true, false);
     }
 

--- a/src/access/BaseAccessControls.sol
+++ b/src/access/BaseAccessControls.sol
@@ -7,10 +7,12 @@ import '../types/LenderStatus.sol';
 import './IRoleProvider.sol';
 import './ProviderStructs.sol';
 import './IRoleProviderFactory.sol';
+import './IHooksAdministrator.sol';
+import '../interfaces/IWildcatArchController.sol';
 
 using BoolUtils for bool;
 
-contract BaseAccessControls {
+contract BaseAccessControls is IHooksAdministrator {
   // ========================================================================== //
   //                                   Events                                   //
   // ========================================================================== //
@@ -42,12 +44,29 @@ contract BaseAccessControls {
   event AccountAccessRevoked(address indexed accountAddress);
   event AccountMadeFirstDeposit(address indexed market, address indexed accountAddress);
   event NameUpdated(string name);
+  event AdministratorTransferRequested(
+    address indexed administrator,
+    address indexed previousPendingAdministrator,
+    address indexed pendingAdministrator
+  );
+  event AdministratorTransferCancelled(
+    address indexed administrator,
+    address indexed cancelledPendingAdministrator
+  );
+  event AdministratorTransferred(
+    address indexed previousAdministrator,
+    address indexed newAdministrator
+  );
 
   // ========================================================================== //
   //                                   Errors                                   //
   // ========================================================================== //
 
-  error CallerNotBorrower();
+  error CallerNotAdministrator();
+  error InvalidAdministratorTransferTarget();
+  error AdministratorNotRegistered();
+  error NoPendingAdministratorTransfer();
+  error NotPendingAdministrator();
   error ProviderNotFound();
   error ProviderCanNotReplaceCredential();
   error ProviderCanNotRevokeCredential();
@@ -67,7 +86,9 @@ contract BaseAccessControls {
   //                                    State                                   //
   // ========================================================================== //
 
-  address public immutable borrower;
+  address public override administrator;
+  address public override pendingAdministrator;
+  address internal immutable _hooksFactory;
   // Name of the hooks instance
   string public name;
   // Credentials by lender address
@@ -82,8 +103,8 @@ contract BaseAccessControls {
   //                                  Modifiers                                 //
   // ========================================================================== //
 
-  modifier onlyBorrower() {
-    if (msg.sender != borrower) revert CallerNotBorrower();
+  modifier onlyAdministrator() {
+    if (msg.sender != administrator) revert CallerNotAdministrator();
     _;
   }
 
@@ -91,17 +112,9 @@ contract BaseAccessControls {
   //                                 Constructor                                //
   // ========================================================================== //
 
-  constructor(address _borrower) {
-    borrower = _borrower;
-    // Allow deployer to grant roles with no expiry
-    RoleProvider borrowerProvider = encodeRoleProvider(
-      type(uint32).max,
-      _borrower,
-      NullProviderIndex,
-      0
-    );
-    _roleProviders[borrower] = borrowerProvider;
-    _pushProviders.push(borrowerProvider);
+  constructor(address _administrator) {
+    administrator = _administrator;
+    _hooksFactory = msg.sender;
   }
 
   function _initialize(NameAndProviderInputs memory inputs) internal {
@@ -123,8 +136,65 @@ contract BaseAccessControls {
     }
   }
 
-  /// @dev Borrower-only setter for this hooks instance name.
-  function setName(string memory _name) external onlyBorrower {
+  /// @dev Compatibility alias for integrations that still call the hook administrator `borrower`.
+  function borrower() external view returns (address) {
+    return administrator;
+  }
+
+  // ========================================================================== //
+  //                         Administrator transfer                             //
+  // ========================================================================== //
+
+  function _validateAdministratorTransferTarget(address newAdministrator) internal view {
+    if (newAdministrator == address(0) || newAdministrator == administrator) {
+      revert InvalidAdministratorTransferTarget();
+    }
+    address archController = IHooksFactoryAdministratorCallback(_hooksFactory).archController();
+    if (!IWildcatArchController(archController).isRegisteredBorrower(newAdministrator)) {
+      revert AdministratorNotRegistered();
+    }
+  }
+
+  function requestAdministratorTransfer(
+    address newAdministrator
+  ) external override onlyAdministrator {
+    _validateAdministratorTransferTarget(newAdministrator);
+    address previousPendingAdministrator = pendingAdministrator;
+    pendingAdministrator = newAdministrator;
+    emit AdministratorTransferRequested(
+      msg.sender,
+      previousPendingAdministrator,
+      newAdministrator
+    );
+  }
+
+  function cancelAdministratorTransfer() external override onlyAdministrator {
+    address cancelledPendingAdministrator = pendingAdministrator;
+    if (cancelledPendingAdministrator == address(0)) {
+      revert NoPendingAdministratorTransfer();
+    }
+    pendingAdministrator = address(0);
+    emit AdministratorTransferCancelled(msg.sender, cancelledPendingAdministrator);
+  }
+
+  function acceptAdministratorTransfer() external override {
+    address newAdministrator = pendingAdministrator;
+    if (msg.sender != newAdministrator) revert NotPendingAdministrator();
+    _validateAdministratorTransferTarget(newAdministrator);
+
+    address previousAdministrator = administrator;
+    pendingAdministrator = address(0);
+    administrator = newAdministrator;
+    emit AdministratorTransferred(previousAdministrator, newAdministrator);
+
+    IHooksFactoryAdministratorCallback(_hooksFactory).onHooksAdministratorTransferred(
+      previousAdministrator,
+      newAdministrator
+    );
+  }
+
+  /// @dev Administrator-only setter for this hooks instance name.
+  function setName(string memory _name) external onlyAdministrator {
     name = _name;
     emit NameUpdated(_name);
   }
@@ -134,14 +204,14 @@ contract BaseAccessControls {
   // ========================================================================== //
 
   /**
-   * @dev Borrower-only helper that creates a role provider through `providerFactory`
+   * @dev Administrator-only helper that creates a role provider through `providerFactory`
    *      and adds it with the supplied TTL. Reverts if creation returns address(0).
    */
   function createRoleProvider(
     address providerFactory,
     uint32 timeToLive,
     bytes memory data
-  ) external onlyBorrower {
+  ) external onlyAdministrator {
     _createRoleProvider(IRoleProviderFactory(providerFactory), timeToLive, data);
   }
 
@@ -162,7 +232,7 @@ contract BaseAccessControls {
    *      otherwise, it is added to `pushProviders`.
    *      If the provider is already approved, only updates `timeToLive`.
    */
-  function addRoleProvider(address providerAddress, uint32 timeToLive) external onlyBorrower {
+  function addRoleProvider(address providerAddress, uint32 timeToLive) external onlyAdministrator {
     _addRoleProvider(providerAddress, timeToLive);
   }
 
@@ -221,7 +291,7 @@ contract BaseAccessControls {
    * @dev Removes a role provider from the `_roleProviders` mapping and, if it is a
    *      pull provider, from the `_pullProviders` array.
    */
-  function removeRoleProvider(address providerAddress) external onlyBorrower {
+  function removeRoleProvider(address providerAddress) external onlyAdministrator {
     RoleProvider provider = _roleProviders[providerAddress];
     if (provider.isNull()) revert ProviderNotFound();
     // Remove the provider from `_roleProviders`
@@ -481,13 +551,13 @@ contract BaseAccessControls {
     emit AccountAccessRevoked(account);
   }
 
-  /// @dev Borrower-only block that clears any credential and prevents future deposits.
-  function blockFromDeposits(address account) external onlyBorrower {
+  /// @dev Administrator-only block that clears any credential and prevents future deposits.
+  function blockFromDeposits(address account) external onlyAdministrator {
     _blockFromDeposits(account);
   }
 
-  /// @dev Borrower-only batch version of `blockFromDeposits`.
-  function blockFromDeposits(address[] calldata accounts) external onlyBorrower {
+  /// @dev Administrator-only batch version of `blockFromDeposits`.
+  function blockFromDeposits(address[] calldata accounts) external onlyAdministrator {
     for (uint256 i; i < accounts.length; i++) {
       _blockFromDeposits(accounts[i]);
     }
@@ -504,8 +574,8 @@ contract BaseAccessControls {
     emit AccountBlockedFromDeposits(account);
   }
 
-  /// @dev Borrower-only unblock that lets the account deposit if otherwise approved.
-  function unblockFromDeposits(address account) external onlyBorrower {
+  /// @dev Administrator-only unblock that lets the account deposit if otherwise approved.
+  function unblockFromDeposits(address account) external onlyAdministrator {
     LenderStatus memory status = _lenderStatus[account];
     status.isBlockedFromDeposits = false;
     _lenderStatus[account] = status;

--- a/src/access/BaseAccessControls.sol
+++ b/src/access/BaseAccessControls.sol
@@ -622,7 +622,7 @@ contract BaseAccessControls is IHooksAdministrator {
   }
 
   /**
-   * @dev A zero-TTL pull provider is the source of truth on every check, including
+   * @dev A zero-TTL pull credential cannot satisfy a check from cache, including
    *      another check in the same block. Push providers keep their existing
    *      timestamp behavior because the hook cannot refresh them.
    */

--- a/src/access/FixedTermHooks.sol
+++ b/src/access/FixedTermHooks.sol
@@ -25,17 +25,16 @@ struct HookedMarket {
 /**
  * @title FixedTermHooks
  * @dev Hooks contract for wildcat markets. Restricts access to deposits
- *      to accounts that have credentials from approved role providers, or
- *      which are manually approved by the borrower. Restricts withdrawals
- *      until a fixed loan term has elapsed, which can be reduced but not
- *      increased by the borrower.
+ *      to accounts that have credentials from approved role providers.
+ *      Restricts withdrawals until a fixed loan term has elapsed, which the
+ *      hook administrator can reduce but not increase.
  *
  *      Withdrawals are restricted in the same way for users that have not
  *      made a deposit, while users who have made a deposit at any point (or
  *      received market tokens while having deposit access) will always remain
  *      approved, even if their access is later revoked.
  *
- *      Deposit access may be canceled by the borrower.
+ *      Deposit access may be blocked by the hook administrator.
  */
 contract FixedTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTransferPolicy {
   // ========================================================================== //
@@ -79,11 +78,14 @@ contract FixedTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTra
   // ========================================================================== //
 
   /**
-   * @param _deployer Address of the account that called the factory.
+   * @param _administrator Initial administrator for the hooks instance.
    * @param args Optional abi-encoded `NameAndProviderInputs` struct to initialize
    *             the providers and name for the hooks instance.
    */
-  constructor(address _deployer, bytes memory args) BaseAccessControls(_deployer) IHooks() {
+  constructor(
+    address _administrator,
+    bytes memory args
+  ) BaseAccessControls(_administrator) IHooks() {
     HooksConfig optionalFlags = encodeHooksConfig({
       hooksAddress: address(0),
       useOnDeposit: true,
@@ -139,8 +141,8 @@ contract FixedTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTra
   /**
    * @dev Called when market is deployed using this contract as its `hooks`.
    *
-   *     @param deployer      Address of the account that called the factory - must
-   *                          match the borrower address.
+   *     @param administrator_ Principal supplied by the factory. Must match the
+   *                           hooks administrator.
    *     @param marketAddress Address of the market being deployed.
    *     @param parameters    Parameters used to deploy the market.
    *     @param hooksData     Extra data passed to the market deployment function containing
@@ -159,14 +161,14 @@ contract FixedTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTra
    *      so no need to verify the caller is the factory.
    */
   function _onCreateMarket(
-    address deployer,
+    address administrator_,
     address marketAddress,
     DeployMarketInputs calldata parameters,
     bytes calldata hooksData
   ) internal override returns (HooksConfig marketHooksConfig) {
     // Validate the deploy parameters
-    super._onCreateMarket(deployer, marketAddress, parameters, hooksData);
-    if (deployer != borrower) revert CallerNotBorrower();
+    super._onCreateMarket(administrator_, marketAddress, parameters, hooksData);
+    if (administrator_ != administrator) revert CallerNotAdministrator();
     if (hooksData.length < 32) revert FixedTermNotProvided();
 
     marketHooksConfig = parameters.hooks;
@@ -239,7 +241,7 @@ contract FixedTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTra
    *      later adopt a positive minimum.
    *      Reverts if `market` was not created with this hooks instance.
    */
-  function setMinimumDeposit(address market, uint128 newMinimumDeposit) external onlyBorrower {
+  function setMinimumDeposit(address market, uint128 newMinimumDeposit) external onlyAdministrator {
     HookedMarket storage hookedMarket = _hookedMarkets[market];
     if (!hookedMarket.isHooked) revert NotHookedMarket();
     if (newMinimumDeposit > 0 && !_depositHookEnabled[market]) revert DepositHookNotEnabled();
@@ -248,10 +250,13 @@ contract FixedTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTra
   }
 
   /**
-   * @dev Borrower-only setter for a hooked market's fixed-term end time.
+   * @dev Administrator-only setter for a hooked market's fixed-term end time.
    *      Reverts if the market is unknown, term reduction is disabled or term is extended.
    */
-  function setFixedTermEndTime(address market, uint32 newFixedTermEndTime) external onlyBorrower {
+  function setFixedTermEndTime(
+    address market,
+    uint32 newFixedTermEndTime
+  ) external onlyAdministrator {
     HookedMarket storage hookedMarket = _hookedMarkets[market];
     if (!hookedMarket.isHooked) revert NotHookedMarket();
     if (!hookedMarket.allowTermReduction && newFixedTermEndTime <= hookedMarket.fixedTermEndTime)

--- a/src/access/IAccessListRoleProvider.sol
+++ b/src/access/IAccessListRoleProvider.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import './IRoleProvider.sol';
+import './IManagedRoleProvider.sol';
+
+interface IAccessListRoleProvider is IRoleProvider, IManagedRoleProvider {
+  event MemberAdded(address indexed administrator, address indexed account);
+  event MemberRemoved(address indexed administrator, address indexed account);
+
+  error InvalidMember();
+  error MemberAlreadyExists();
+  error MemberNotFound();
+  error InvalidPaginationRange();
+
+  function isMember(address account) external view returns (bool);
+
+  function addMember(address account) external;
+
+  function addMembers(address[] calldata accounts) external;
+
+  function removeMember(address account) external;
+
+  function removeMembers(address[] calldata accounts) external;
+
+  function getMembers() external view returns (address[] memory);
+
+  function getMembers(uint256 start, uint256 end) external view returns (address[] memory);
+
+  function getMembersCount() external view returns (uint256);
+}

--- a/src/access/IAccessListRoleProviderFactory.sol
+++ b/src/access/IAccessListRoleProviderFactory.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import './IRoleProviderFactory.sol';
+
+struct AccessListRoleProviderFactoryInputs {
+  address administrator;
+  address[] initialMembers;
+  bytes32 salt;
+}
+
+interface IAccessListRoleProviderFactory is IRoleProviderFactory {
+  error RoleProviderAlreadyExists();
+
+  event AccessListRoleProviderDeployed(
+    address indexed provider,
+    address indexed administrator,
+    address indexed deployer,
+    bytes32 salt,
+    address[] initialMembers
+  );
+
+  function createAccessListRoleProvider(
+    AccessListRoleProviderFactoryInputs calldata inputs
+  ) external returns (address provider);
+
+  function computeRoleProviderAddress(
+    address deployer,
+    AccessListRoleProviderFactoryInputs calldata inputs
+  ) external view returns (address provider);
+}

--- a/src/access/IHooks.sol
+++ b/src/access/IHooks.sol
@@ -23,20 +23,21 @@ abstract contract IHooks {
   function config() external view virtual returns (HooksDeploymentConfig);
 
   /// @dev Factory-only hook called before deploying a market with this hooks contract.
+  ///      `administrator` is the principal authorized to configure this hooks instance.
   ///      Reverts if caller is not the factory.
   ///      Returns the hooks config to store on the market.
   function onCreateMarket(
-    address deployer,
+    address administrator,
     address marketAddress,
     DeployMarketInputs calldata parameters,
     bytes calldata extraData
   ) external returns (HooksConfig) {
     if (msg.sender != factory) revert CallerNotFactory();
-    return _onCreateMarket(deployer, marketAddress, parameters, extraData);
+    return _onCreateMarket(administrator, marketAddress, parameters, extraData);
   }
 
   function _onCreateMarket(
-    address deployer,
+    address administrator,
     address marketAddress,
     DeployMarketInputs calldata parameters,
     bytes calldata extraData

--- a/src/access/IHooksAdministrator.sol
+++ b/src/access/IHooksAdministrator.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IHooksAdministrator {
+  function administrator() external view returns (address);
+
+  function pendingAdministrator() external view returns (address);
+
+  function requestAdministratorTransfer(address newAdministrator) external;
+
+  function cancelAdministratorTransfer() external;
+
+  function acceptAdministratorTransfer() external;
+}
+
+interface IHooksFactoryAdministratorCallback {
+  function archController() external view returns (address);
+
+  function onHooksAdministratorTransferred(
+    address previousAdministrator,
+    address newAdministrator
+  ) external;
+}

--- a/src/access/IManagedRoleProvider.sol
+++ b/src/access/IManagedRoleProvider.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @dev Optional administration interface for role providers whose authority can move.
+ *      Role providers are not required to implement this interface.
+ */
+interface IManagedRoleProvider {
+  event AdministratorTransferRequested(
+    address indexed administrator,
+    address indexed previousPendingAdministrator,
+    address indexed pendingAdministrator
+  );
+  event AdministratorTransferCancelled(
+    address indexed administrator,
+    address indexed cancelledPendingAdministrator
+  );
+  event AdministratorTransferred(
+    address indexed previousAdministrator,
+    address indexed newAdministrator
+  );
+
+  error CallerNotAdministrator();
+  error InvalidAdministratorTransferTarget();
+  error NoPendingAdministratorTransfer();
+  error NotPendingAdministrator();
+
+  function administrator() external view returns (address);
+
+  function pendingAdministrator() external view returns (address);
+
+  function requestAdministratorTransfer(address newAdministrator) external;
+
+  function cancelAdministratorTransfer() external;
+
+  function acceptAdministratorTransfer() external;
+}

--- a/src/access/MarketConstraintHooks.sol
+++ b/src/access/MarketConstraintHooks.sol
@@ -135,7 +135,7 @@ abstract contract MarketConstraintHooks is IHooks {
   }
 
   function _onCreateMarket(
-    address /* deployer */,
+    address /* administrator */,
     address /* marketAddress */,
     DeployMarketInputs calldata parameters,
     bytes calldata /* extraData */

--- a/src/access/OpenTermHooks.sol
+++ b/src/access/OpenTermHooks.sol
@@ -21,15 +21,14 @@ struct HookedMarket {
 /**
  * @title OpenTermHooks
  * @dev Hooks contract for wildcat markets. Restricts access to deposits
- *      to accounts that have credentials from approved role providers, or
- *      which are manually approved by the borrower.
+ *      to accounts that have credentials from approved role providers.
  *
  *      Withdrawals are restricted in the same way for users that have not
  *      made a deposit, while users who have made a deposit at any point (or
  *      received market tokens while having deposit access) will always remain
  *      approved, even if their access is later revoked.
  *
- *      Deposit access may be canceled by the borrower.
+ *      Deposit access may be blocked by the hook administrator.
  */
 contract OpenTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTransferPolicy {
   // ========================================================================== //
@@ -62,11 +61,14 @@ contract OpenTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTran
   // ========================================================================== //
 
   /**
-   * @param _deployer Address of the account that called the factory.
+   * @param _administrator Initial administrator for the hooks instance.
    * @param args Optional abi-encoded `NameAndProviderInputs` struct to initialize
    *             the providers and name for the hooks instance.
    */
-  constructor(address _deployer, bytes memory args) BaseAccessControls(_deployer) IHooks() {
+  constructor(
+    address _administrator,
+    bytes memory args
+  ) BaseAccessControls(_administrator) IHooks() {
     HooksConfig optionalFlags = encodeHooksConfig({
       hooksAddress: address(0),
       useOnDeposit: true,
@@ -113,8 +115,8 @@ contract OpenTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTran
   /**
    * @dev Called when market is deployed using this contract as its `hooks`.
    *
-   *     @param deployer      Address of the account that called the factory - must
-   *                          match the borrower address.
+   *     @param administrator_ Principal supplied by the factory. Must match the
+   *                           hooks administrator.
    *     @param marketAddress Address of the market being deployed.
    *     @param parameters    Parameters used to deploy the market.
    *     @param hooksData     Extra data passed to the market deployment function containing
@@ -130,14 +132,14 @@ contract OpenTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTran
    *      so no need to verify the caller is the factory.
    */
   function _onCreateMarket(
-    address deployer,
+    address administrator_,
     address marketAddress,
     DeployMarketInputs calldata parameters,
     bytes calldata hooksData
   ) internal override returns (HooksConfig marketHooksConfig) {
     // Validate the deploy parameters
-    super._onCreateMarket(deployer, marketAddress, parameters, hooksData);
-    if (deployer != borrower) revert CallerNotBorrower();
+    super._onCreateMarket(administrator_, marketAddress, parameters, hooksData);
+    if (administrator_ != administrator) revert CallerNotAdministrator();
     marketHooksConfig = parameters.hooks;
 
     // Read `minimumDeposit` and `transfersDisabled` from `hooksData`
@@ -194,7 +196,7 @@ contract OpenTermHooks is BaseAccessControls, MarketConstraintHooks, IMarketTran
    *      later adopt a positive minimum.
    *      Reverts if `market` was not created with this hooks instance.
    */
-  function setMinimumDeposit(address market, uint128 newMinimumDeposit) external onlyBorrower {
+  function setMinimumDeposit(address market, uint128 newMinimumDeposit) external onlyAdministrator {
     HookedMarket storage hookedMarket = _hookedMarkets[market];
     if (!hookedMarket.isHooked) revert NotHookedMarket();
     if (newMinimumDeposit > 0 && !_depositHookEnabled[market]) revert DepositHookNotEnabled();

--- a/src/access/PeriodicTermHooks.sol
+++ b/src/access/PeriodicTermHooks.sol
@@ -144,11 +144,14 @@ contract PeriodicTermHooks is BaseAccessControls, MarketConstraintHooks, IMarket
   // ========================================================================== //
 
   /**
-   * @param _deployer Address of the account that called the factory.
+   * @param _administrator Initial administrator for the hooks instance.
    * @param args Optional abi-encoded `NameAndProviderInputs` struct to initialize
    *             the providers and name for the hooks instance.
    */
-  constructor(address _deployer, bytes memory args) BaseAccessControls(_deployer) IHooks() {
+  constructor(
+    address _administrator,
+    bytes memory args
+  ) BaseAccessControls(_administrator) IHooks() {
     HooksConfig optionalFlags = encodeHooksConfig({
       hooksAddress: address(0),
       useOnDeposit: true,
@@ -222,8 +225,8 @@ contract PeriodicTermHooks is BaseAccessControls, MarketConstraintHooks, IMarket
   /**
    * @dev Called when market is deployed using this contract as its `hooks`.
    *
-   *     @param deployer      Address of the account that called the factory - must
-   *                          match the borrower address.
+   *     @param administrator_ Principal supplied by the factory. Must match the
+   *                           hooks administrator.
    *     @param marketAddress Address of the market being deployed.
    *     @param parameters    Parameters used to deploy the market.
    *     @param hooksData     Extra data passed to the market deployment function containing
@@ -245,13 +248,13 @@ contract PeriodicTermHooks is BaseAccessControls, MarketConstraintHooks, IMarket
    *      so no need to verify the caller is the factory.
    */
   function _onCreateMarket(
-    address deployer,
+    address administrator_,
     address marketAddress,
     DeployMarketInputs calldata parameters,
     bytes calldata hooksData
   ) internal override returns (HooksConfig marketHooksConfig) {
-    super._onCreateMarket(deployer, marketAddress, parameters, hooksData);
-    if (deployer != borrower) revert CallerNotBorrower();
+    super._onCreateMarket(administrator_, marketAddress, parameters, hooksData);
+    if (administrator_ != administrator) revert CallerNotAdministrator();
     if (hooksData.length < 0x60) revert PeriodicWindowNotProvided();
 
     marketHooksConfig = parameters.hooks;
@@ -330,7 +333,7 @@ contract PeriodicTermHooks is BaseAccessControls, MarketConstraintHooks, IMarket
    *      later adopt a positive minimum.
    *      Reverts if `market` was not created with this hooks instance.
    */
-  function setMinimumDeposit(address market, uint128 newMinimumDeposit) external onlyBorrower {
+  function setMinimumDeposit(address market, uint128 newMinimumDeposit) external onlyAdministrator {
     HookedMarket storage hookedMarket = _hookedMarkets[market];
     if (!hookedMarket.isHooked) revert NotHookedMarket();
     if (newMinimumDeposit > 0 && !hookedMarket.depositHookEnabled) revert DepositHookNotEnabled();
@@ -342,7 +345,7 @@ contract PeriodicTermHooks is BaseAccessControls, MarketConstraintHooks, IMarket
   function proposeAnnualInterestBips(
     address market,
     uint16 annualInterestBips
-  ) external onlyBorrower {
+  ) external onlyAdministrator {
     HookedMarket memory hookedMarket = _hookedMarkets[market];
     if (!hookedMarket.isHooked) revert NotHookedMarket();
     if (hookedMarket.isClosed) revert AprReductionProposalOnClosedMarket();

--- a/test/BaseMarketTest.sol
+++ b/test/BaseMarketTest.sol
@@ -74,17 +74,17 @@ contract BaseMarketTest is Test, ExpectedStateTracker {
     setUpContracts(false);
   }
 
-  function _authorizeLender(address account) internal asAccount(parameters.borrower) {
+  function _authorizeLender(address account) internal asAccount(address(ecdsaRoleProvider)) {
     vm.expectEmit(address(hooks));
     emit BaseAccessControls.AccountAccessGranted(
-      parameters.borrower,
+      address(ecdsaRoleProvider),
       account,
       uint32(block.timestamp)
     );
     hooks.grantRole(account, uint32(block.timestamp));
   }
 
-  function _deauthorizeLender(address account) internal asAccount(parameters.borrower) {
+  function _deauthorizeLender(address account) internal asAccount(address(ecdsaRoleProvider)) {
     vm.expectEmit(address(hooks));
     emit BaseAccessControls.AccountAccessRevoked(account);
     hooks.revokeRole(account);

--- a/test/BorrowerAccountOrigination.t.sol
+++ b/test/BorrowerAccountOrigination.t.sol
@@ -118,7 +118,7 @@ contract BorrowerAccountOriginationTest is Test {
     WildcatMarket market = WildcatMarket(marketAddress);
     assertEq(market.borrower(), expectedBorrower, 'operational borrower');
     assertEq(market.borrowerPrincipal(), expectedPrincipal, 'borrower principal');
-    assertEq(OpenTermHooks(hooksInstance).borrower(), expectedPrincipal, 'hook borrower');
+    assertEq(OpenTermHooks(hooksInstance).administrator(), expectedPrincipal, 'hook administrator');
   }
 
   function _transferAccountPrincipal(address newPrincipal) internal {
@@ -158,8 +158,11 @@ contract BorrowerAccountOriginationTest is Test {
     vm.stopPrank();
 
     _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
-    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 1);
-    assertEq(standardFactory.getHooksInstancesCountForBorrower(borrowerAccount), 0);
+    assertEq(standardFactory.getHooksAdministrator(hooksInstance), principal);
+    assertEq(standardFactory.getHooksInstancesCountForAdministrator(principal), 1);
+    assertEq(standardFactory.getHooksInstancesCountForAdministrator(borrowerAccount), 0);
+    assertEq(standardFactory.getHooksInstanceDeploymentNonce(principal), 1);
+    assertEq(standardFactory.getHooksInstanceDeploymentNonce(borrowerAccount), 0);
     _assertAccountAuthority(market);
   }
 
@@ -177,8 +180,11 @@ contract BorrowerAccountOriginationTest is Test {
     vm.stopPrank();
 
     _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
-    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 1);
-    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(borrowerAccount), 0);
+    assertEq(revolvingFactory.getHooksAdministrator(hooksInstance), principal);
+    assertEq(revolvingFactory.getHooksInstancesCountForAdministrator(principal), 1);
+    assertEq(revolvingFactory.getHooksInstancesCountForAdministrator(borrowerAccount), 0);
+    assertEq(revolvingFactory.getHooksInstanceDeploymentNonce(principal), 1);
+    assertEq(revolvingFactory.getHooksInstanceDeploymentNonce(borrowerAccount), 0);
     _assertAccountAuthority(market);
   }
 
@@ -195,7 +201,7 @@ contract BorrowerAccountOriginationTest is Test {
     );
 
     _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
-    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 1);
+    assertEq(standardFactory.getHooksAdministrator(hooksInstance), principal);
   }
 
   function test_revolvingAccountDeploysMarketAndHookTogether() external {
@@ -212,7 +218,7 @@ contract BorrowerAccountOriginationTest is Test {
     );
 
     _assertMarketIdentity(market, hooksInstance, borrowerAccount, principal);
-    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 1);
+    assertEq(revolvingFactory.getHooksAdministrator(hooksInstance), principal);
   }
 
   function test_accountPaysOriginationFees() external {
@@ -353,7 +359,7 @@ contract BorrowerAccountOriginationTest is Test {
     assertEq(revolvingFactory.getMarketsForHooksInstanceCount(revolvingHooks), 2);
   }
 
-  function test_accountsUnderOnePrincipalShareHookDeploymentSequence() external {
+  function test_accountsUnderOnePrincipalShareHookDeploymentNonce() external {
     address secondAccount = accountFactory.deployAccount(principal);
 
     vm.prank(borrowerAccount);
@@ -368,12 +374,14 @@ contract BorrowerAccountOriginationTest is Test {
 
     assertTrue(firstStandardHooks != secondStandardHooks);
     assertTrue(firstRevolvingHooks != secondRevolvingHooks);
-    assertEq(OpenTermHooks(firstStandardHooks).borrower(), principal);
-    assertEq(OpenTermHooks(secondStandardHooks).borrower(), principal);
-    assertEq(OpenTermHooks(firstRevolvingHooks).borrower(), principal);
-    assertEq(OpenTermHooks(secondRevolvingHooks).borrower(), principal);
-    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 2);
-    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 2);
+    assertEq(standardFactory.getHooksAdministrator(firstStandardHooks), principal);
+    assertEq(standardFactory.getHooksAdministrator(secondStandardHooks), principal);
+    assertEq(revolvingFactory.getHooksAdministrator(firstRevolvingHooks), principal);
+    assertEq(revolvingFactory.getHooksAdministrator(secondRevolvingHooks), principal);
+    assertEq(standardFactory.getHooksInstanceDeploymentNonce(principal), 2);
+    assertEq(revolvingFactory.getHooksInstanceDeploymentNonce(principal), 2);
+    assertEq(standardFactory.getHooksInstancesCountForAdministrator(principal), 2);
+    assertEq(revolvingFactory.getHooksInstancesCountForAdministrator(principal), 2);
   }
 
   function test_accountCannotOriginateAfterPrincipalRemoval() external {
@@ -387,8 +395,8 @@ contract BorrowerAccountOriginationTest is Test {
     vm.expectRevert(IHooksFactoryEventsAndErrors.NotApprovedBorrower.selector);
     revolvingFactory.deployHooksInstance(hooksTemplate, '');
 
-    assertEq(standardFactory.getHooksInstancesCountForBorrower(principal), 0);
-    assertEq(revolvingFactory.getHooksInstancesCountForBorrower(principal), 0);
+    assertEq(standardFactory.getHooksInstanceDeploymentNonce(principal), 0);
+    assertEq(revolvingFactory.getHooksInstanceDeploymentNonce(principal), 0);
   }
 
   function test_accountOriginationSurvivesAccountFactoryRemoval() external {
@@ -426,7 +434,7 @@ contract BorrowerAccountOriginationTest is Test {
     vm.prank(secondPrincipal);
     address standardHooks = standardFactory.deployHooksInstance(hooksTemplate, '');
     vm.prank(borrowerAccount);
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     standardFactory.deployMarket(
       _marketInputs(standardHooks),
       '',
@@ -438,7 +446,7 @@ contract BorrowerAccountOriginationTest is Test {
     vm.prank(secondPrincipal);
     address revolvingHooks = revolvingFactory.deployHooksInstance(hooksTemplate, '');
     vm.prank(borrowerAccount);
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     revolvingFactory.deployMarket(
       _marketInputs(revolvingHooks),
       '',

--- a/test/HooksAdministratorTransfer.t.sol
+++ b/test/HooksAdministratorTransfer.t.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.20;
+
+import 'forge-std/Test.sol';
+import 'src/WildcatArchController.sol';
+import 'src/WildcatBorrowerIdentityRegistry.sol';
+import 'src/HooksFactory.sol';
+import 'src/HooksFactoryRevolving.sol';
+import 'src/market/WildcatMarket.sol';
+import 'src/market/WildcatMarketRevolving.sol';
+import 'src/access/OpenTermHooks.sol';
+import 'src/libraries/LibStoredInitCode.sol';
+
+contract HooksAdministratorTransferTest is Test {
+  WildcatArchController internal archController;
+  WildcatBorrowerIdentityRegistry internal borrowerIdentityRegistry;
+  IHooksFactory internal standardFactory;
+  IHooksFactory internal revolvingFactory;
+  address internal hooksTemplate;
+
+  address internal constant NewAdministrator = address(0xA11CE);
+  address internal constant SecondAdministrator = address(0xB0B);
+
+  function setUp() external {
+    archController = new WildcatArchController();
+    borrowerIdentityRegistry = new WildcatBorrowerIdentityRegistry(address(archController));
+    hooksTemplate = LibStoredInitCode.deployInitCode(type(OpenTermHooks).creationCode);
+
+    address standardMarketInitCode = LibStoredInitCode.deployInitCode(
+      type(WildcatMarket).creationCode
+    );
+    address revolvingMarketInitCode = LibStoredInitCode.deployInitCode(
+      type(WildcatMarketRevolving).creationCode
+    );
+    standardFactory = IHooksFactory(
+      address(
+        new HooksFactory(
+          address(archController),
+          address(1),
+          address(this),
+          standardMarketInitCode,
+          uint256(keccak256(type(WildcatMarket).creationCode)),
+          address(borrowerIdentityRegistry)
+        )
+      )
+    );
+    revolvingFactory = IHooksFactory(
+      address(
+        new HooksFactoryRevolving(
+          address(archController),
+          address(1),
+          address(this),
+          revolvingMarketInitCode,
+          uint256(keccak256(type(WildcatMarketRevolving).creationCode)),
+          address(borrowerIdentityRegistry)
+        )
+      )
+    );
+
+    archController.registerControllerFactory(address(standardFactory));
+    archController.registerControllerFactory(address(revolvingFactory));
+    standardFactory.registerWithArchController();
+    revolvingFactory.registerWithArchController();
+    standardFactory.addHooksTemplate(hooksTemplate, 'Open Term', address(0), address(0), 0, 0);
+    revolvingFactory.addHooksTemplate(hooksTemplate, 'Open Term', address(0), address(0), 0, 0);
+
+    archController.registerBorrower(address(this));
+    archController.registerBorrower(NewAdministrator);
+    archController.registerBorrower(SecondAdministrator);
+  }
+
+  function _deployHooks(IHooksFactory factory) internal returns (OpenTermHooks hooks) {
+    hooks = OpenTermHooks(factory.deployHooksInstance(hooksTemplate, ''));
+  }
+
+  function _assertInitialAssociation(IHooksFactory factory) internal {
+    OpenTermHooks hooks = _deployHooks(factory);
+    address[] memory instances = factory.getHooksInstancesForAdministrator(address(this));
+
+    assertEq(hooks.administrator(), address(this), 'administrator');
+    assertEq(hooks.pendingAdministrator(), address(0), 'pending administrator');
+    assertEq(factory.getHooksAdministrator(address(hooks)), address(this), 'factory administrator');
+    assertEq(instances.length, 1, 'administrator instances');
+    assertEq(instances[0], address(hooks), 'administrator instance');
+    assertEq(
+      factory.getHooksInstancesCountForAdministrator(address(this)),
+      1,
+      'administrator instance count'
+    );
+    assertEq(
+      factory.getHooksInstancesForAdministrator(address(this), 0, 1),
+      instances,
+      'administrator instance page'
+    );
+    assertEq(
+      factory.getHooksInstancesForBorrower(address(this)),
+      instances,
+      'borrower compatibility alias'
+    );
+    assertEq(
+      factory.getHooksInstancesCountForBorrower(address(this)),
+      1,
+      'borrower count compatibility alias'
+    );
+  }
+
+  function _acceptTransfer(
+    IHooksFactory factory,
+    OpenTermHooks hooks,
+    address newAdministrator
+  ) internal {
+    hooks.requestAdministratorTransfer(newAdministrator);
+
+    vm.expectEmit(address(hooks));
+    emit BaseAccessControls.AdministratorTransferred(address(this), newAdministrator);
+    vm.expectEmit(address(factory));
+    emit IHooksFactoryEventsAndErrors.HooksInstanceAdministratorTransferred(
+      address(hooks),
+      address(this),
+      newAdministrator
+    );
+    vm.prank(newAdministrator);
+    hooks.acceptAdministratorTransfer();
+  }
+
+  function _assertTransfer(IHooksFactory factory) internal {
+    OpenTermHooks hooks = _deployHooks(factory);
+    hooks.requestAdministratorTransfer(NewAdministrator);
+
+    assertEq(factory.getHooksAdministrator(address(hooks)), address(this), 'pending factory state');
+    assertEq(
+      factory.getHooksInstancesCountForAdministrator(NewAdministrator),
+      0,
+      'pending administrator instances'
+    );
+
+    vm.expectEmit(address(hooks));
+    emit BaseAccessControls.AdministratorTransferred(address(this), NewAdministrator);
+    vm.expectEmit(address(factory));
+    emit IHooksFactoryEventsAndErrors.HooksInstanceAdministratorTransferred(
+      address(hooks),
+      address(this),
+      NewAdministrator
+    );
+    vm.prank(NewAdministrator);
+    hooks.acceptAdministratorTransfer();
+
+    assertEq(hooks.administrator(), NewAdministrator, 'administrator');
+    assertEq(factory.getHooksAdministrator(address(hooks)), NewAdministrator, 'factory administrator');
+    assertEq(
+      factory.getHooksInstancesCountForAdministrator(address(this)),
+      0,
+      'previous administrator instances'
+    );
+    address[] memory instances = factory.getHooksInstancesForAdministrator(NewAdministrator);
+    assertEq(instances.length, 1, 'new administrator instances');
+    assertEq(instances[0], address(hooks), 'new administrator instance');
+
+    vm.prank(address(hooks));
+    vm.expectRevert(IHooksFactoryEventsAndErrors.InvalidHooksAdministrator.selector);
+    factory.onHooksAdministratorTransferred(address(this), NewAdministrator);
+  }
+
+  function _assertSwapAndPop(IHooksFactory factory) internal {
+    OpenTermHooks firstHooks = _deployHooks(factory);
+    OpenTermHooks secondHooks = _deployHooks(factory);
+
+    _acceptTransfer(factory, firstHooks, NewAdministrator);
+    address[] memory remainingInstances = factory.getHooksInstancesForAdministrator(address(this));
+    assertEq(remainingInstances.length, 1, 'remaining instances');
+    assertEq(remainingInstances[0], address(secondHooks), 'moved instance');
+
+    _acceptTransfer(factory, secondHooks, SecondAdministrator);
+    assertEq(
+      factory.getHooksInstancesCountForAdministrator(address(this)),
+      0,
+      'previous administrator instances'
+    );
+    address[] memory secondAdministratorInstances = factory.getHooksInstancesForAdministrator(
+      SecondAdministrator
+    );
+    assertEq(secondAdministratorInstances.length, 1, 'second administrator instances');
+    assertEq(secondAdministratorInstances[0], address(secondHooks), 'second administrator instance');
+  }
+
+  function _assertCallbackAuthentication(IHooksFactory factory) internal {
+    OpenTermHooks hooks = _deployHooks(factory);
+
+    vm.expectRevert(IHooksFactoryEventsAndErrors.HooksInstanceNotFound.selector);
+    factory.onHooksAdministratorTransferred(address(this), NewAdministrator);
+
+    vm.prank(address(hooks));
+    vm.expectRevert(IHooksFactoryEventsAndErrors.InvalidHooksAdministrator.selector);
+    factory.onHooksAdministratorTransferred(address(this), NewAdministrator);
+
+    assertEq(factory.getHooksAdministrator(address(hooks)), address(this), 'factory administrator');
+  }
+
+  function _assertDeploymentNonceSurvivesTransfer(IHooksFactory factory) internal {
+    OpenTermHooks firstHooks = _deployHooks(factory);
+    _acceptTransfer(factory, firstHooks, NewAdministrator);
+
+    OpenTermHooks secondHooks = _deployHooks(factory);
+    assertNotEq(address(secondHooks), address(firstHooks), 'hooks instance');
+    assertEq(factory.getHooksInstanceDeploymentNonce(address(this)), 2, 'deployment nonce');
+
+    address[] memory previousAdministratorInstances = factory
+      .getHooksInstancesForAdministrator(address(this));
+    assertEq(previousAdministratorInstances.length, 1, 'previous administrator instances');
+    assertEq(previousAdministratorInstances[0], address(secondHooks), 'new hooks instance');
+  }
+
+  function test_initialAdministratorAssociation() external {
+    _assertInitialAssociation(standardFactory);
+    _assertInitialAssociation(revolvingFactory);
+  }
+
+  function test_administratorTransferUpdatesFactoryAssociation() external {
+    _assertTransfer(standardFactory);
+    _assertTransfer(revolvingFactory);
+  }
+
+  function test_administratorTransferUpdatesSwapAndPopIndex() external {
+    _assertSwapAndPop(standardFactory);
+    _assertSwapAndPop(revolvingFactory);
+  }
+
+  function test_factoryCallbackAuthentication() external {
+    _assertCallbackAuthentication(standardFactory);
+    _assertCallbackAuthentication(revolvingFactory);
+  }
+
+  function test_deploymentNonceSurvivesAdministratorTransfer() external {
+    _assertDeploymentNonceSurvivesTransfer(standardFactory);
+    _assertDeploymentNonceSurvivesTransfer(revolvingFactory);
+  }
+}

--- a/test/HooksFactory.t.sol
+++ b/test/HooksFactory.t.sol
@@ -705,11 +705,11 @@ contract HooksFactoryTest is Test, Assertions {
       initCodeHash := keccak256(initCodePointer, initCodeSizeWithArgs)
     }
 
-    uint256 numPreviousInstances = hooksFactory.getHooksInstancesCountForBorrower(borrower);
+    uint256 deploymentNonce = hooksFactory.getHooksInstanceDeploymentNonce(borrower);
     bytes32 salt;
 
     assembly {
-      salt := or(shl(96, borrower), numPreviousInstances)
+      salt := or(shl(96, borrower), deploymentNonce)
     }
 
     return
@@ -738,7 +738,11 @@ contract HooksFactoryTest is Test, Assertions {
     address expectedAddress
   ) internal {
     vm.expectEmit(address(hooksFactory));
-    emit IHooksFactoryEventsAndErrors.HooksInstanceDeployed(expectedAddress, hooksTemplate);
+    emit IHooksFactoryEventsAndErrors.HooksInstanceDeployed(
+      expectedAddress,
+      hooksTemplate,
+      address(this)
+    );
   }
 
   function _validateDeployedHooksInstance(

--- a/test/access/AccessListRoleProvider.t.sol
+++ b/test/access/AccessListRoleProvider.t.sol
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.20;
+
+import 'forge-std/Test.sol';
+import 'src/access/AccessListRoleProvider.sol';
+import 'src/access/AccessListRoleProviderFactory.sol';
+
+contract AccessListRoleProviderTest is Test {
+  address internal constant Alice = address(0xA11CE);
+  address internal constant Bob = address(0xB0B);
+  address internal constant Carol = address(0xCA201);
+
+  AccessListRoleProvider internal provider;
+
+  function setUp() external {
+    vm.warp(1_714_737_030);
+    address[] memory initialMembers = new address[](1);
+    initialMembers[0] = Alice;
+    provider = new AccessListRoleProvider(address(this), initialMembers);
+  }
+
+  function test_constructor() external view {
+    assertEq(provider.administrator(), address(this), 'administrator');
+    assertEq(provider.pendingAdministrator(), address(0), 'pending administrator');
+    assertTrue(provider.isPullProvider(), 'pull provider');
+    assertTrue(provider.isMember(Alice), 'alice member');
+    assertEq(provider.getMembersCount(), 1, 'member count');
+
+    address[] memory members = provider.getMembers();
+    assertEq(members.length, 1, 'members length');
+    assertEq(members[0], Alice, 'members[0]');
+  }
+
+  function test_constructor_InvalidAdministrator() external {
+    vm.expectRevert(IManagedRoleProvider.InvalidAdministratorTransferTarget.selector);
+    new AccessListRoleProvider(address(0), new address[](0));
+  }
+
+  function test_constructor_InvalidInitialMember() external {
+    address[] memory initialMembers = new address[](1);
+    vm.expectRevert(IAccessListRoleProvider.InvalidMember.selector);
+    new AccessListRoleProvider(address(this), initialMembers);
+  }
+
+  function test_constructor_DuplicateInitialMember() external {
+    address[] memory initialMembers = new address[](2);
+    initialMembers[0] = Alice;
+    initialMembers[1] = Alice;
+    vm.expectRevert(IAccessListRoleProvider.MemberAlreadyExists.selector);
+    new AccessListRoleProvider(address(this), initialMembers);
+  }
+
+  function test_getCredential_TracksCurrentMembership() external {
+    assertEq(provider.getCredential(Alice), block.timestamp, 'initial timestamp');
+    assertEq(provider.getCredential(Bob), 0, 'unlisted timestamp');
+
+    vm.warp(block.timestamp + 1 days);
+    assertEq(provider.getCredential(Alice), block.timestamp, 'refreshed timestamp');
+
+    provider.removeMember(Alice);
+    assertEq(provider.getCredential(Alice), 0, 'removed timestamp');
+
+    provider.addMember(Alice);
+    assertEq(provider.getCredential(Alice), block.timestamp, 're-added timestamp');
+  }
+
+  function test_validateCredential_UsesMembership() external view {
+    assertEq(provider.validateCredential(Alice, hex'1234'), block.timestamp, 'member');
+    assertEq(provider.validateCredential(Bob, hex'1234'), 0, 'non-member');
+  }
+
+  function test_providerInstancesKeepSeparateLists() external {
+    address[] memory initialMembers = new address[](1);
+    initialMembers[0] = Bob;
+    AccessListRoleProvider otherProvider = new AccessListRoleProvider(
+      address(this),
+      initialMembers
+    );
+
+    provider.removeMember(Alice);
+
+    assertFalse(provider.isMember(Alice), 'first alice');
+    assertFalse(provider.isMember(Bob), 'first bob');
+    assertFalse(otherProvider.isMember(Alice), 'second alice');
+    assertTrue(otherProvider.isMember(Bob), 'second bob');
+  }
+
+  function test_addAndRemoveMember() external {
+    vm.expectEmit(address(provider));
+    emit IAccessListRoleProvider.MemberAdded(address(this), Bob);
+    provider.addMember(Bob);
+
+    assertTrue(provider.isMember(Bob), 'member after add');
+    assertEq(provider.getMembersCount(), 2, 'count after add');
+
+    vm.expectEmit(address(provider));
+    emit IAccessListRoleProvider.MemberRemoved(address(this), Bob);
+    provider.removeMember(Bob);
+
+    assertFalse(provider.isMember(Bob), 'member after remove');
+    assertEq(provider.getMembersCount(), 1, 'count after remove');
+  }
+
+  function test_addAndRemoveMembers() external {
+    address[] memory accounts = new address[](2);
+    accounts[0] = Bob;
+    accounts[1] = Carol;
+
+    provider.addMembers(accounts);
+    assertTrue(provider.isMember(Bob), 'bob member');
+    assertTrue(provider.isMember(Carol), 'carol member');
+    assertEq(provider.getMembersCount(), 3, 'count after add');
+
+    provider.removeMembers(accounts);
+    assertFalse(provider.isMember(Bob), 'bob removed');
+    assertFalse(provider.isMember(Carol), 'carol removed');
+    assertEq(provider.getMembersCount(), 1, 'count after remove');
+  }
+
+  function test_batchUpdateIsAtomic() external {
+    address[] memory accounts = new address[](2);
+    accounts[0] = Bob;
+    accounts[1] = address(0);
+
+    vm.expectRevert(IAccessListRoleProvider.InvalidMember.selector);
+    provider.addMembers(accounts);
+    assertFalse(provider.isMember(Bob), 'partial add');
+  }
+
+  function test_memberUpdateErrors() external {
+    vm.expectRevert(IAccessListRoleProvider.InvalidMember.selector);
+    provider.addMember(address(0));
+
+    vm.expectRevert(IAccessListRoleProvider.MemberAlreadyExists.selector);
+    provider.addMember(Alice);
+
+    vm.expectRevert(IAccessListRoleProvider.MemberNotFound.selector);
+    provider.removeMember(Bob);
+  }
+
+  function test_memberUpdatesRequireAdministrator() external {
+    vm.startPrank(Bob);
+    vm.expectRevert(IManagedRoleProvider.CallerNotAdministrator.selector);
+    provider.addMember(Bob);
+    vm.expectRevert(IManagedRoleProvider.CallerNotAdministrator.selector);
+    provider.removeMember(Alice);
+    vm.stopPrank();
+  }
+
+  function test_getMembers_Pagination() external {
+    provider.addMember(Bob);
+    provider.addMember(Carol);
+
+    address[] memory members = provider.getMembers(1, 3);
+    assertEq(members.length, 2, 'page length');
+    assertEq(members[0], Bob, 'page[0]');
+    assertEq(members[1], Carol, 'page[1]');
+
+    assertEq(provider.getMembers(3, 10).length, 0, 'empty page');
+    assertEq(provider.getMembers(10, 20).length, 0, 'past end');
+
+    vm.expectRevert(IAccessListRoleProvider.InvalidPaginationRange.selector);
+    provider.getMembers(2, 1);
+  }
+
+  function test_requestAdministratorTransfer_ReplacesPending() external {
+    vm.expectEmit(address(provider));
+    emit IManagedRoleProvider.AdministratorTransferRequested(address(this), address(0), Bob);
+    provider.requestAdministratorTransfer(Bob);
+
+    vm.expectEmit(address(provider));
+    emit IManagedRoleProvider.AdministratorTransferRequested(address(this), Bob, Carol);
+    provider.requestAdministratorTransfer(Carol);
+
+    assertEq(provider.administrator(), address(this), 'administrator');
+    assertEq(provider.pendingAdministrator(), Carol, 'pending administrator');
+  }
+
+  function test_cancelAdministratorTransfer() external {
+    provider.requestAdministratorTransfer(Bob);
+
+    vm.expectEmit(address(provider));
+    emit IManagedRoleProvider.AdministratorTransferCancelled(address(this), Bob);
+    provider.cancelAdministratorTransfer();
+
+    assertEq(provider.pendingAdministrator(), address(0), 'pending administrator');
+
+    vm.expectRevert(IManagedRoleProvider.NoPendingAdministratorTransfer.selector);
+    provider.cancelAdministratorTransfer();
+  }
+
+  function test_acceptAdministratorTransfer_PreservesMembership() external {
+    provider.requestAdministratorTransfer(Bob);
+
+    vm.prank(Bob);
+    vm.expectRevert(IManagedRoleProvider.CallerNotAdministrator.selector);
+    provider.addMember(Carol);
+
+    vm.prank(Bob);
+    vm.expectEmit(address(provider));
+    emit IManagedRoleProvider.AdministratorTransferred(address(this), Bob);
+    provider.acceptAdministratorTransfer();
+
+    assertEq(provider.administrator(), Bob, 'administrator');
+    assertEq(provider.pendingAdministrator(), address(0), 'pending administrator');
+    assertTrue(provider.isMember(Alice), 'membership');
+
+    vm.expectRevert(IManagedRoleProvider.CallerNotAdministrator.selector);
+    provider.removeMember(Alice);
+
+    vm.expectRevert(IManagedRoleProvider.CallerNotAdministrator.selector);
+    provider.requestAdministratorTransfer(Carol);
+
+    vm.prank(Bob);
+    provider.removeMember(Alice);
+    assertFalse(provider.isMember(Alice), 'member removed by new administrator');
+  }
+
+  function test_administratorTransferErrors() external {
+    vm.expectRevert(IManagedRoleProvider.InvalidAdministratorTransferTarget.selector);
+    provider.requestAdministratorTransfer(address(0));
+
+    vm.expectRevert(IManagedRoleProvider.InvalidAdministratorTransferTarget.selector);
+    provider.requestAdministratorTransfer(address(this));
+
+    vm.prank(Bob);
+    vm.expectRevert(IManagedRoleProvider.CallerNotAdministrator.selector);
+    provider.requestAdministratorTransfer(Carol);
+
+    vm.prank(Bob);
+    vm.expectRevert(IManagedRoleProvider.NotPendingAdministrator.selector);
+    provider.acceptAdministratorTransfer();
+  }
+}
+
+contract AccessListRoleProviderFactoryCaller {
+  function createRoleProvider(
+    AccessListRoleProviderFactory factory,
+    bytes calldata data
+  ) external returns (address) {
+    return factory.createRoleProvider(data);
+  }
+}
+
+contract AccessListRoleProviderFactoryTest is Test {
+  address internal constant Alice = address(0xA11CE);
+  address internal constant Bob = address(0xB0B);
+
+  AccessListRoleProviderFactory internal factory;
+
+  function setUp() external {
+    vm.warp(1_714_737_030);
+    factory = new AccessListRoleProviderFactory();
+  }
+
+  function _inputs(
+    address administrator,
+    bytes32 salt
+  ) internal pure returns (AccessListRoleProviderFactoryInputs memory inputs) {
+    inputs.administrator = administrator;
+    inputs.salt = salt;
+    inputs.initialMembers = new address[](1);
+    inputs.initialMembers[0] = Alice;
+  }
+
+  function test_createAccessListRoleProvider() external {
+    AccessListRoleProviderFactoryInputs memory inputs = _inputs(address(this), bytes32('salt'));
+    address expected = factory.computeRoleProviderAddress(address(this), inputs);
+    address actual = factory.createAccessListRoleProvider(inputs);
+
+    assertEq(actual, expected, 'provider');
+    assertEq(AccessListRoleProvider(actual).administrator(), address(this), 'administrator');
+    assertTrue(AccessListRoleProvider(actual).isMember(Alice), 'initial member');
+  }
+
+  function test_createRoleProvider_GenericInterface() external {
+    AccessListRoleProviderFactoryInputs memory inputs = _inputs(Bob, bytes32('generic'));
+    address expected = factory.computeRoleProviderAddress(address(this), inputs);
+    address actual = factory.createRoleProvider(abi.encode(inputs));
+
+    assertEq(actual, expected, 'provider');
+    assertEq(AccessListRoleProvider(actual).administrator(), Bob, 'administrator');
+  }
+
+  function test_deploymentEvent() external {
+    AccessListRoleProviderFactoryInputs memory inputs;
+    inputs.administrator = address(this);
+    inputs.salt = bytes32('event');
+    inputs.initialMembers = new address[](0);
+    address expected = factory.computeRoleProviderAddress(address(this), inputs);
+
+    vm.expectEmit(address(factory));
+    emit IAccessListRoleProviderFactory.AccessListRoleProviderDeployed(
+      expected,
+      address(this),
+      address(this),
+      inputs.salt,
+      inputs.initialMembers
+    );
+    factory.createAccessListRoleProvider(inputs);
+  }
+
+  function test_saltIsNamespacedByCaller() external {
+    AccessListRoleProviderFactoryInputs memory inputs = _inputs(address(this), bytes32('shared'));
+    AccessListRoleProviderFactoryCaller caller = new AccessListRoleProviderFactoryCaller();
+
+    address first = factory.createRoleProvider(abi.encode(inputs));
+    address second = caller.createRoleProvider(factory, abi.encode(inputs));
+
+    assertNotEq(first, second, 'provider addresses');
+    assertEq(
+      second,
+      factory.computeRoleProviderAddress(address(caller), inputs),
+      'namespaced address'
+    );
+  }
+
+  function test_duplicateDeploymentReverts() external {
+    AccessListRoleProviderFactoryInputs memory inputs = _inputs(address(this), bytes32('duplicate'));
+    factory.createAccessListRoleProvider(inputs);
+
+    vm.expectRevert(IAccessListRoleProviderFactory.RoleProviderAlreadyExists.selector);
+    factory.createAccessListRoleProvider(inputs);
+  }
+
+  function test_malformedInitializationReverts() external {
+    vm.expectRevert();
+    factory.createRoleProvider(hex'1234');
+  }
+
+  function test_invalidInitializationReverts() external {
+    AccessListRoleProviderFactoryInputs memory inputs = _inputs(address(0), bytes32('invalid'));
+    vm.expectRevert(IManagedRoleProvider.InvalidAdministratorTransferTarget.selector);
+    factory.createAccessListRoleProvider(inputs);
+  }
+}

--- a/test/access/AccessListRoleProviderIntegration.t.sol
+++ b/test/access/AccessListRoleProviderIntegration.t.sol
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.8.20;
+
+import 'forge-std/Test.sol';
+import 'src/access/AccessListRoleProvider.sol';
+import 'src/access/AccessListRoleProviderFactory.sol';
+import { OpenTermHooks } from 'src/access/OpenTermHooks.sol';
+import 'src/access/ProviderStructs.sol';
+import 'src/types/LenderStatus.sol';
+import 'src/types/RoleProvider.sol';
+import { MockOpenTermHooks } from '../shared/mocks/MockOpenTermHooks.sol';
+import { MockFixedTermHooks } from '../shared/mocks/MockFixedTermHooks.sol';
+
+contract AccessListRoleProviderIntegrationTest is Test {
+  address internal constant Lender = address(0x1EAD);
+  address internal constant NewAdministrator = address(0xA11CE);
+
+  AccessListRoleProviderFactory internal factory;
+  MockOpenTermHooks internal openTermHooks;
+  MockFixedTermHooks internal fixedTermHooks;
+
+  function setUp() external {
+    vm.warp(1_714_737_030);
+    factory = new AccessListRoleProviderFactory();
+    openTermHooks = new MockOpenTermHooks(address(this));
+    fixedTermHooks = new MockFixedTermHooks(address(this));
+  }
+
+  function _deployAndAttachProvider(
+    uint32 timeToLive,
+    bytes32 salt
+  ) internal returns (AccessListRoleProvider provider) {
+    AccessListRoleProviderFactoryInputs memory inputs;
+    inputs.administrator = address(this);
+    inputs.salt = salt;
+    inputs.initialMembers = new address[](1);
+    inputs.initialMembers[0] = Lender;
+
+    address providerAddress = factory.computeRoleProviderAddress(address(openTermHooks), inputs);
+    openTermHooks.createRoleProvider(address(factory), timeToLive, abi.encode(inputs));
+    fixedTermHooks.addRoleProvider(providerAddress, timeToLive);
+    provider = AccessListRoleProvider(providerAddress);
+  }
+
+  function _validateOnBothHooks(
+    bool expectedValid,
+    bool expectedUpdate
+  ) internal {
+    (bool valid, bool wasUpdated) = openTermHooks.tryValidateAccess(Lender, '');
+    assertEq(valid, expectedValid, 'open valid');
+    assertEq(wasUpdated, expectedUpdate, 'open updated');
+
+    (valid, wasUpdated) = fixedTermHooks.tryValidateAccess(Lender, '');
+    assertEq(valid, expectedValid, 'fixed valid');
+    assertEq(wasUpdated, expectedUpdate, 'fixed updated');
+  }
+
+  function test_factoryCalledByHookAssignsIntendedAdministrator() external {
+    AccessListRoleProvider provider = _deployAndAttachProvider(0, bytes32('administrator'));
+
+    assertEq(provider.administrator(), address(this), 'provider administrator');
+    assertTrue(provider.isMember(Lender), 'member');
+    assertFalse(openTermHooks.getRoleProvider(address(provider)).isNull(), 'open attachment');
+    assertFalse(fixedTermHooks.getRoleProvider(address(provider)).isNull(), 'fixed attachment');
+  }
+
+  function test_hookConstructorCreatesAndAttachesProvider() external {
+    AccessListRoleProviderFactoryInputs memory providerInputs;
+    providerInputs.administrator = address(this);
+    providerInputs.salt = bytes32('constructor');
+    providerInputs.initialMembers = new address[](1);
+    providerInputs.initialMembers[0] = Lender;
+
+    NameAndProviderInputs memory hookInputs;
+    hookInputs.roleProviderFactory = address(factory);
+    hookInputs.newProviderInputs = new CreateProviderInputs[](1);
+    hookInputs.newProviderInputs[0] = CreateProviderInputs({
+      timeToLive: 0,
+      providerFactoryCalldata: abi.encode(providerInputs)
+    });
+
+    OpenTermHooks hooks = new OpenTermHooks(address(this), abi.encode(hookInputs));
+    address expectedProvider = factory.computeRoleProviderAddress(address(hooks), providerInputs);
+
+    RoleProvider[] memory providers = hooks.getPullProviders();
+    assertEq(providers.length, 1, 'provider count');
+    assertEq(providers[0].providerAddress(), expectedProvider, 'provider address');
+    assertEq(
+      AccessListRoleProvider(expectedProvider).administrator(),
+      address(this),
+      'provider administrator'
+    );
+    assertTrue(AccessListRoleProvider(expectedProvider).isMember(Lender), 'initial member');
+  }
+
+  function test_zeroTtlRemovalAppliesToBothHooksInSameBlock() external {
+    AccessListRoleProvider provider = _deployAndAttachProvider(0, bytes32('zero ttl'));
+    _validateOnBothHooks(true, true);
+
+    provider.removeMember(Lender);
+
+    LenderStatus memory openStatus = openTermHooks.getLenderStatus(Lender);
+    LenderStatus memory fixedStatus = fixedTermHooks.getLenderStatus(Lender);
+    assertEq(openStatus.lastProvider, address(0), 'open view status');
+    assertEq(fixedStatus.lastProvider, address(0), 'fixed view status');
+    _validateOnBothHooks(false, true);
+
+    vm.warp(block.timestamp + 1);
+    _validateOnBothHooks(false, false);
+  }
+
+  function test_positiveTtlDelaysRemovalUntilCacheExpires() external {
+    uint32 timeToLive = 1 days;
+    AccessListRoleProvider provider = _deployAndAttachProvider(
+      timeToLive,
+      bytes32('positive ttl')
+    );
+    _validateOnBothHooks(true, true);
+
+    provider.removeMember(Lender);
+    _validateOnBothHooks(true, false);
+
+    vm.warp(block.timestamp + timeToLive + 1);
+    _validateOnBothHooks(false, true);
+  }
+
+  function test_providerGrantDoesNotClearHookLocalBlock() external {
+    _deployAndAttachProvider(0, bytes32('local block'));
+    openTermHooks.blockFromDeposits(Lender);
+
+    (bool valid, bool wasUpdated) = openTermHooks.tryValidateAccess(Lender, '');
+    assertTrue(valid, 'credential valid');
+    assertTrue(wasUpdated, 'credential updated');
+
+    LenderStatus memory status = openTermHooks.getPreviousLenderStatus(Lender);
+    assertTrue(status.isBlockedFromDeposits, 'open local block');
+    assertFalse(
+      fixedTermHooks.getPreviousLenderStatus(Lender).isBlockedFromDeposits,
+      'fixed local block'
+    );
+  }
+
+  function test_providerTransferPreservesMembershipAndAttachments() external {
+    AccessListRoleProvider provider = _deployAndAttachProvider(0, bytes32('transfer'));
+    RoleProvider openAttachment = openTermHooks.getRoleProvider(address(provider));
+    RoleProvider fixedAttachment = fixedTermHooks.getRoleProvider(address(provider));
+
+    provider.requestAdministratorTransfer(NewAdministrator);
+    vm.prank(NewAdministrator);
+    provider.acceptAdministratorTransfer();
+
+    assertTrue(provider.isMember(Lender), 'member');
+    assertEq(
+      RoleProvider.unwrap(openTermHooks.getRoleProvider(address(provider))),
+      RoleProvider.unwrap(openAttachment),
+      'open attachment'
+    );
+    assertEq(
+      RoleProvider.unwrap(fixedTermHooks.getRoleProvider(address(provider))),
+      RoleProvider.unwrap(fixedAttachment),
+      'fixed attachment'
+    );
+
+    vm.expectRevert(IManagedRoleProvider.CallerNotAdministrator.selector);
+    provider.removeMember(Lender);
+
+    vm.prank(NewAdministrator);
+    provider.removeMember(Lender);
+    assertFalse(provider.isMember(Lender), 'member removed');
+  }
+}

--- a/test/access/BaseAccessControls.t.sol
+++ b/test/access/BaseAccessControls.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.8.20;
 import 'forge-std/Test.sol';
 import 'src/access/BaseAccessControls.sol';
 import 'src/access/IRoleProvider.sol';
+import 'src/WildcatArchController.sol';
 import { LibString } from 'solady/utils/LibString.sol';
 import '../shared/mocks/MockRoleProvider.sol';
 import '../shared/mocks/MockRoleProviderFactory.sol';
@@ -31,6 +32,8 @@ abstract contract MockBaseAccessControls is BaseAccessControls {
 }
 
 abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
+  error AdministratorTransferCallbackFailed();
+
   uint24 internal numPullProviders;
   uint24 internal numPushProviders;
   StandardRoleProvider[] internal expectedRoleProviders;
@@ -38,9 +41,46 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
   MockRoleProvider internal mockProvider1 = new MockRoleProvider();
   MockRoleProvider internal mockProvider2 = new MockRoleProvider();
   MockRoleProviderFactory internal providerFactory = new MockRoleProviderFactory();
+  WildcatArchController internal hookArchController;
+  bool internal failAdministratorTransferCallback;
+  address internal callbackPreviousAdministrator;
+  address internal callbackNewAdministrator;
 
   bytes4 internal constant Panic_ErrorSelector = 0x4e487b71;
   uint256 internal constant Panic_Arithmetic = 0x11;
+
+  function _setUpBaseHooks(MockBaseAccessControls _baseHooks) internal {
+    baseHooks = _baseHooks;
+    hookArchController = new WildcatArchController();
+    hookArchController.registerBorrower(address(this));
+  }
+
+  function archController() external view returns (address) {
+    return address(hookArchController);
+  }
+
+  function onHooksAdministratorTransferred(
+    address previousAdministrator,
+    address newAdministrator
+  ) external {
+    if (failAdministratorTransferCallback) revert AdministratorTransferCallbackFailed();
+    assertEq(msg.sender, address(baseHooks), 'callback caller');
+    callbackPreviousAdministrator = previousAdministrator;
+    callbackNewAdministrator = newAdministrator;
+  }
+
+  function _registerAdministrator(address account) internal {
+    if (!hookArchController.isRegisteredBorrower(account)) {
+      hookArchController.registerBorrower(account);
+    }
+  }
+
+  function _transferAdministrator(address newAdministrator) internal {
+    _registerAdministrator(newAdministrator);
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+    vm.prank(newAdministrator);
+    baseHooks.acceptAdministratorTransfer();
+  }
 
   function _getIsKnownLenderStatus(AccessControlHooksFuzzContext memory context) internal {
     baseHooks.setIsKnownLender(context.account, context.market, true);
@@ -171,12 +211,257 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
   }
 
   // ========================================================================== //
+  //                         Administrator transfer                             //
+  // ========================================================================== //
+
+  function test_constructor_DoesNotAddAdministratorAsProvider() external {
+    assertTrue(baseHooks.getRoleProvider(address(this)).isNull(), 'administrator provider');
+    assertEq(baseHooks.getPullProviders().length, 0, 'pull providers');
+    assertEq(baseHooks.getPushProviders().length, 0, 'push providers');
+
+    vm.expectRevert(BaseAccessControls.ProviderNotFound.selector);
+    baseHooks.grantRole(address(1), uint32(block.timestamp));
+  }
+
+  function test_requestAdministratorTransfer() external {
+    address newAdministrator = address(0xA11CE);
+    _registerAdministrator(newAdministrator);
+
+    vm.expectEmit(address(baseHooks));
+    emit BaseAccessControls.AdministratorTransferRequested(
+      address(this),
+      address(0),
+      newAdministrator
+    );
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+
+    assertEq(baseHooks.administrator(), address(this), 'administrator');
+    assertEq(baseHooks.pendingAdministrator(), newAdministrator, 'pending administrator');
+  }
+
+  function test_requestAdministratorTransfer_ReplacesPendingAdministrator() external {
+    address firstAdministrator = address(0xA11CE);
+    address secondAdministrator = address(0xB0B);
+    _registerAdministrator(firstAdministrator);
+    _registerAdministrator(secondAdministrator);
+    baseHooks.requestAdministratorTransfer(firstAdministrator);
+
+    vm.expectEmit(address(baseHooks));
+    emit BaseAccessControls.AdministratorTransferRequested(
+      address(this),
+      firstAdministrator,
+      secondAdministrator
+    );
+    baseHooks.requestAdministratorTransfer(secondAdministrator);
+
+    assertEq(baseHooks.pendingAdministrator(), secondAdministrator, 'pending administrator');
+  }
+
+  function test_requestAdministratorTransfer_InvalidTargets() external {
+    vm.expectRevert(BaseAccessControls.InvalidAdministratorTransferTarget.selector);
+    baseHooks.requestAdministratorTransfer(address(0));
+
+    vm.expectRevert(BaseAccessControls.InvalidAdministratorTransferTarget.selector);
+    baseHooks.requestAdministratorTransfer(address(this));
+
+    vm.expectRevert(BaseAccessControls.AdministratorNotRegistered.selector);
+    baseHooks.requestAdministratorTransfer(address(0xBAD));
+  }
+
+  function test_requestAdministratorTransfer_CallerNotAdministrator() external {
+    vm.prank(address(1));
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    baseHooks.requestAdministratorTransfer(address(2));
+  }
+
+  function test_cancelAdministratorTransfer() external {
+    address newAdministrator = address(0xA11CE);
+    _registerAdministrator(newAdministrator);
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+
+    vm.expectEmit(address(baseHooks));
+    emit BaseAccessControls.AdministratorTransferCancelled(address(this), newAdministrator);
+    baseHooks.cancelAdministratorTransfer();
+
+    assertEq(baseHooks.pendingAdministrator(), address(0), 'pending administrator');
+  }
+
+  function test_cancelAdministratorTransfer_NoPendingTransfer() external {
+    vm.expectRevert(BaseAccessControls.NoPendingAdministratorTransfer.selector);
+    baseHooks.cancelAdministratorTransfer();
+  }
+
+  function test_cancelAdministratorTransfer_CallerNotAdministrator() external {
+    vm.prank(address(1));
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    baseHooks.cancelAdministratorTransfer();
+  }
+
+  function test_acceptAdministratorTransfer() external {
+    address newAdministrator = address(0xA11CE);
+    _registerAdministrator(newAdministrator);
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+
+    vm.expectEmit(address(baseHooks));
+    emit BaseAccessControls.AdministratorTransferred(address(this), newAdministrator);
+    vm.prank(newAdministrator);
+    baseHooks.acceptAdministratorTransfer();
+
+    assertEq(baseHooks.administrator(), newAdministrator, 'administrator');
+    assertEq(baseHooks.borrower(), newAdministrator, 'borrower alias');
+    assertEq(baseHooks.pendingAdministrator(), address(0), 'pending administrator');
+    assertEq(callbackPreviousAdministrator, address(this), 'callback previous administrator');
+    assertEq(callbackNewAdministrator, newAdministrator, 'callback new administrator');
+  }
+
+  function test_acceptAdministratorTransfer_PendingAdministratorHasNoAuthority() external {
+    address newAdministrator = address(0xA11CE);
+    _registerAdministrator(newAdministrator);
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+
+    vm.prank(newAdministrator);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    baseHooks.setName('too early');
+  }
+
+  function test_acceptAdministratorTransfer_OnlyPendingAdministratorCanAccept() external {
+    address newAdministrator = address(0xA11CE);
+    _registerAdministrator(newAdministrator);
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+
+    vm.prank(address(0xB0B));
+    vm.expectRevert(BaseAccessControls.NotPendingAdministrator.selector);
+    baseHooks.acceptAdministratorTransfer();
+  }
+
+  function test_acceptAdministratorTransfer_RevalidatesRegistration() external {
+    address newAdministrator = address(0xA11CE);
+    _registerAdministrator(newAdministrator);
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+    hookArchController.removeBorrower(newAdministrator);
+
+    vm.prank(newAdministrator);
+    vm.expectRevert(BaseAccessControls.AdministratorNotRegistered.selector);
+    baseHooks.acceptAdministratorTransfer();
+
+    assertEq(baseHooks.administrator(), address(this), 'administrator');
+    assertEq(baseHooks.pendingAdministrator(), newAdministrator, 'pending administrator');
+  }
+
+  function test_acceptAdministratorTransfer_CallbackFailureRevertsTransfer() external {
+    address newAdministrator = address(0xA11CE);
+    _registerAdministrator(newAdministrator);
+    baseHooks.requestAdministratorTransfer(newAdministrator);
+    failAdministratorTransferCallback = true;
+
+    vm.prank(newAdministrator);
+    vm.expectRevert(AdministratorTransferCallbackFailed.selector);
+    baseHooks.acceptAdministratorTransfer();
+
+    assertEq(baseHooks.administrator(), address(this), 'administrator');
+    assertEq(baseHooks.pendingAdministrator(), newAdministrator, 'pending administrator');
+  }
+
+  function test_acceptAdministratorTransfer_PreservesAccessState() external {
+    address lender = address(0x1EAD);
+    address blockedLender = address(0xB10C);
+    address market = address(0xCAFE);
+    address newAdministrator = address(0xA11CE);
+    mockProvider1.setIsPullProvider(true);
+    mockProvider2.setIsPullProvider(false);
+    baseHooks.addRoleProvider(address(mockProvider1), type(uint32).max);
+    baseHooks.addRoleProvider(address(mockProvider2), 30 days);
+    vm.prank(address(mockProvider1));
+    baseHooks.grantRole(lender, uint32(block.timestamp));
+    baseHooks.blockFromDeposits(blockedLender);
+    baseHooks.setIsKnownLender(lender, market, true);
+
+    bytes32 pullProvidersBefore = keccak256(abi.encode(baseHooks.getPullProviders()));
+    bytes32 pushProvidersBefore = keccak256(abi.encode(baseHooks.getPushProviders()));
+    RoleProvider pullProviderBefore = baseHooks.getRoleProvider(address(mockProvider1));
+    RoleProvider pushProviderBefore = baseHooks.getRoleProvider(address(mockProvider2));
+    LenderStatus memory statusBefore = baseHooks.getPreviousLenderStatus(lender);
+    LenderStatus memory blockedStatusBefore = baseHooks.getPreviousLenderStatus(blockedLender);
+    _transferAdministrator(newAdministrator);
+
+    assertEq(
+      RoleProvider.unwrap(baseHooks.getRoleProvider(address(mockProvider1))),
+      RoleProvider.unwrap(pullProviderBefore),
+      'pull provider'
+    );
+    assertEq(
+      RoleProvider.unwrap(baseHooks.getRoleProvider(address(mockProvider2))),
+      RoleProvider.unwrap(pushProviderBefore),
+      'push provider'
+    );
+    assertEq(
+      keccak256(abi.encode(baseHooks.getPullProviders())),
+      pullProvidersBefore,
+      'pull providers'
+    );
+    assertEq(
+      keccak256(abi.encode(baseHooks.getPushProviders())),
+      pushProvidersBefore,
+      'push providers'
+    );
+    assertEq(baseHooks.getPreviousLenderStatus(lender), statusBefore, 'lender status');
+    assertEq(
+      baseHooks.getPreviousLenderStatus(blockedLender),
+      blockedStatusBefore,
+      'blocked lender status'
+    );
+    assertTrue(baseHooks.isKnownLenderOnMarket(lender, market), 'known lender');
+
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    baseHooks.setName('old administrator');
+
+    _registerAdministrator(address(0xB0B));
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    baseHooks.requestAdministratorTransfer(address(0xB0B));
+
+    vm.prank(newAdministrator);
+    baseHooks.setName('new administrator');
+    assertEq(baseHooks.name(), 'new administrator', 'name');
+
+    vm.prank(newAdministrator);
+    baseHooks.requestAdministratorTransfer(address(0xB0B));
+    assertEq(baseHooks.pendingAdministrator(), address(0xB0B), 'next pending administrator');
+  }
+
+  function test_grantRole_PreservesDepositBlock() external {
+    address lender = address(0x1EAD);
+    baseHooks.addRoleProvider(address(mockProvider1), type(uint32).max);
+    baseHooks.blockFromDeposits(lender);
+
+    vm.prank(address(mockProvider1));
+    baseHooks.grantRole(lender, uint32(block.timestamp));
+
+    LenderStatus memory status = baseHooks.getPreviousLenderStatus(lender);
+    assertTrue(status.isBlockedFromDeposits, 'deposit block');
+    assertEq(status.lastProvider, address(mockProvider1), 'last provider');
+  }
+
+  function test_refreshRole_PreservesDepositBlock() external {
+    address lender = address(0x1EAD);
+    mockProvider1.setIsPullProvider(true);
+    baseHooks.addRoleProvider(address(mockProvider1), 1);
+    baseHooks.blockFromDeposits(lender);
+    mockProvider1.setCredential(lender, uint32(block.timestamp));
+
+    baseHooks.tryValidateAccess(lender, '');
+
+    LenderStatus memory status = baseHooks.getPreviousLenderStatus(lender);
+    assertTrue(status.isBlockedFromDeposits, 'deposit block');
+    assertEq(status.lastProvider, address(mockProvider1), 'last provider');
+  }
+
+  // ========================================================================== //
   //                                   setName                                  //
   // ========================================================================== //
 
-  function test_setName_CallerNotBorrower() external {
+  function test_setName_CallerNotAdministrator() external {
     vm.prank(address(1));
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     baseHooks.setName('');
   }
 
@@ -191,12 +476,12 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
   //                          Role provider management                          //
   // ========================================================================== //
 
-  function test_createRoleProvider_CallerNotBorrower(
+  function test_createRoleProvider_CallerNotAdministrator(
     bool isPullProvider,
     uint32 timeToLive
   ) external {
     vm.prank(address(1));
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     baseHooks.createRoleProvider(address(1), 0, '');
   }
 
@@ -209,7 +494,7 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
       expectedProviderAddress,
       timeToLive,
       isPullProvider ? 0 : NullProviderIndex,
-      isPullProvider ? NullProviderIndex : 1
+      isPullProvider ? NullProviderIndex : 0
     );
     baseHooks.createRoleProvider(address(providerFactory), timeToLive, factoryInput);
   }
@@ -230,7 +515,7 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
     mockProvider1.setIsPullProvider(isPullProvider);
 
     uint24 pullProviderIndex = isPullProvider ? 0 : NullProviderIndex;
-    uint24 pushProviderIndex = isPullProvider ? NullProviderIndex : 1;
+    uint24 pushProviderIndex = isPullProvider ? NullProviderIndex : 0;
     expectedRoleProviders.push(
       StandardRoleProvider({
         providerAddress: address(mockProvider1),
@@ -251,8 +536,8 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
     _validateRoleProviders();
   }
 
-  function test_addRoleProvider_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_addRoleProvider_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     baseHooks.addRoleProvider(address(2), 1);
   }
 
@@ -388,8 +673,8 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
     _validateRoleProviders();
   }
 
-  function test_removeRoleProvider_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_removeRoleProvider_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     baseHooks.removeRoleProvider(address(mockProvider1));
   }
 
@@ -459,19 +744,19 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
         providerAddress: address(mockProvider2),
         timeToLive: 1,
         pullProviderIndex: NullProviderIndex,
-        pushProviderIndex: 1
+        pushProviderIndex: 0
       })
     );
 
     // Add two pull providers
-    _expectRoleProviderAdded(address(mockProvider1), 1, NullProviderIndex, 1);
+    _expectRoleProviderAdded(address(mockProvider1), 1, NullProviderIndex, 0);
     baseHooks.addRoleProvider(address(mockProvider1), 1);
 
-    _expectRoleProviderAdded(address(mockProvider2), 1, NullProviderIndex, 2);
+    _expectRoleProviderAdded(address(mockProvider2), 1, NullProviderIndex, 1);
     baseHooks.addRoleProvider(address(mockProvider2), 1);
 
-    _expectRoleProviderRemoved(address(mockProvider1), NullProviderIndex, 1);
-    _expectRoleProviderUpdated(address(mockProvider2), 1, NullProviderIndex, 1);
+    _expectRoleProviderRemoved(address(mockProvider1), NullProviderIndex, 0);
+    _expectRoleProviderUpdated(address(mockProvider2), 1, NullProviderIndex, 0);
 
     baseHooks.removeRoleProvider(address(mockProvider1));
     _validateRoleProviders();
@@ -601,8 +886,8 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
     vm.prank(address(mockProvider1));
     baseHooks.grantRole(account, timestamp);
 
-    _expectRoleProviderRemoved(address(mockProvider1), NullProviderIndex, 1);
-    _expectRoleProviderUpdated(address(mockProvider2), timeToLive2, NullProviderIndex, 1);
+    _expectRoleProviderRemoved(address(mockProvider1), NullProviderIndex, 0);
+    _expectRoleProviderUpdated(address(mockProvider2), timeToLive2, NullProviderIndex, 0);
     baseHooks.removeRoleProvider(address(mockProvider1));
 
     _expectAccountAccessGranted(address(mockProvider2), account, timestamp);
@@ -872,6 +1157,8 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
   function test_grantRoles_InvalidArrayLength() external {
     address[] memory accounts = new address[](4);
     uint32[] memory timestamps = new uint32[](3);
+    baseHooks.addRoleProvider(address(mockProvider1), 1);
+    vm.prank(address(mockProvider1));
     vm.expectRevert(BaseAccessControls.InvalidArrayLength.selector);
     baseHooks.grantRoles(accounts, timestamps);
   }
@@ -937,8 +1224,8 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
   //                              blockFromDeposits                             //
   // ========================================================================== //
 
-  function test_blockFromDeposits_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_blockFromDeposits_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     baseHooks.blockFromDeposits(address(1));
   }
 
@@ -965,10 +1252,10 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
     assertEq(status.isBlockedFromDeposits, true, 'isBlockedFromDeposits');
   }
 
-  function test_blockFromDeposits_multiple_CallerNotBorrower() external asAccount(address(1)) {
+  function test_blockFromDeposits_multiple_CallerNotAdministrator() external asAccount(address(1)) {
     address[] memory accounts = new address[](1);
     accounts[0] = address(0);
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     baseHooks.blockFromDeposits(accounts);
   }
 
@@ -1004,8 +1291,8 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
   //                             unblockFromDeposits                            //
   // ========================================================================== //
 
-  function test_unblockFromDeposits_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_unblockFromDeposits_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     baseHooks.unblockFromDeposits(address(1));
   }
 

--- a/test/access/BaseAccessControls.t.sol
+++ b/test/access/BaseAccessControls.t.sol
@@ -973,6 +973,18 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
     assertEq(status.isBlockedFromDeposits, false, 'isBlockedFromDeposits');
   }
 
+  function test_getLenderStatus_ZeroTtlPullProviderRefreshesInSameBlock() external {
+    address bob = address(0xb0b);
+    mockProvider1.setIsPullProvider(true);
+    baseHooks.addRoleProvider(address(mockProvider1), 0);
+    vm.prank(address(mockProvider1));
+    baseHooks.grantRole(bob, uint32(block.timestamp));
+
+    LenderStatus memory status = baseHooks.getLenderStatus(bob);
+    assertEq(status.lastProvider, address(0), 'lastProvider');
+    assertEq(status.lastApprovalTimestamp, 0, 'lastApprovalTimestamp');
+  }
+
   // ========================================================================== //
   //                           getOrValidateCredential                          //
   // ========================================================================== //
@@ -1116,6 +1128,34 @@ abstract contract BaseAccessControlsTest is Test, Assertions, Prankster {
     assertEq(status.lastApprovalTimestamp, newTimestamp, 'lastApprovalTimestamp');
     assertEq(status.canRefresh, true, 'canRefresh');
     assertFalse(status.isBlockedFromDeposits, 'isBlockedFromDeposits');
+  }
+
+  function test_tryValidateAccess_ZeroTtlPullProviderRefreshesInSameBlock() external {
+    address account = address(0xb0b);
+    mockProvider1.setIsPullProvider(true);
+    mockProvider1.setCredential(account, uint32(block.timestamp));
+    baseHooks.addRoleProvider(address(mockProvider1), 0);
+
+    (bool hasValidCredential, bool wasUpdated) = baseHooks.tryValidateAccess(account, '');
+    assertTrue(hasValidCredential, 'initial credential');
+    assertTrue(wasUpdated, 'initial update');
+
+    mockProvider1.setCredential(account, 0);
+    (hasValidCredential, wasUpdated) = baseHooks.tryValidateAccess(account, '');
+    assertFalse(hasValidCredential, 'removed credential');
+    assertTrue(wasUpdated, 'removal update');
+  }
+
+  function test_tryValidateAccess_ZeroTtlPushProviderUsesSameBlockCredential() external {
+    address account = address(0xb0b);
+    mockProvider1.setIsPullProvider(false);
+    baseHooks.addRoleProvider(address(mockProvider1), 0);
+    vm.prank(address(mockProvider1));
+    baseHooks.grantRole(account, uint32(block.timestamp));
+
+    (bool hasValidCredential, bool wasUpdated) = baseHooks.tryValidateAccess(account, '');
+    assertTrue(hasValidCredential, 'hasValidCredential');
+    assertFalse(wasUpdated, 'wasUpdated');
   }
 
   // ========================================================================== //

--- a/test/access/FixedTermHooks.t.sol
+++ b/test/access/FixedTermHooks.t.sol
@@ -17,10 +17,9 @@ contract FixedTermHooksTest is BaseAccessControlsTest {
 
   function setUp() external {
     hooks = new MockFixedTermHooks(address(this));
-    baseHooks = MockBaseAccessControls(address(hooks));
+    _setUpBaseHooks(MockBaseAccessControls(address(hooks)));
     assertEq(hooks.factory(), address(this), 'factory');
-    assertEq(hooks.borrower(), address(this), 'borrower');
-    _addExpectedProvider(MockRoleProvider(address(this)), type(uint32).max, false);
+    assertEq(hooks.administrator(), address(this), 'administrator');
     _validateRoleProviders();
     // Set block.timestamp to 4:50 am, May 3 2024
     warp(1714737030);
@@ -144,10 +143,37 @@ contract FixedTermHooksTest is BaseAccessControlsTest {
     hooks.onCreateMarket(address(1), address(1), inputs, '');
   }
 
-  function test_onCreateMarket_CallerNotBorrower() external {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_onCreateMarket_CallerNotAdministrator() external {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     DeployMarketInputs memory inputs;
     hooks.onCreateMarket(address(1), address(1), inputs, '');
+  }
+
+  function test_acceptAdministratorTransfer_PreservesHookedMarketConfiguration() external {
+    address marketAddress = address(1);
+    address newAdministrator = address(0xA11CE);
+    DeployMarketInputs memory inputs;
+    inputs.hooks = EmptyHooksConfig.setHooksAddress(address(hooks));
+    hooks.onCreateMarket(
+      address(this),
+      marketAddress,
+      inputs,
+      abi.encode(uint32(block.timestamp + 365 days), uint128(100), true, true, true)
+    );
+    bytes32 marketBefore = keccak256(abi.encode(hooks.getHookedMarket(marketAddress)));
+
+    _transferAdministrator(newAdministrator);
+
+    assertEq(
+      keccak256(abi.encode(hooks.getHookedMarket(marketAddress))),
+      marketBefore,
+      'hooked market'
+    );
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    hooks.setMinimumDeposit(marketAddress, 200);
+    vm.prank(newAdministrator);
+    hooks.setMinimumDeposit(marketAddress, 200);
+    assertEq(hooks.getHookedMarket(marketAddress).minimumDeposit, 200, 'minimum deposit');
   }
 
   function test_onCreateMarket_FixedTermNotProvided() external {
@@ -480,8 +506,8 @@ contract FixedTermHooksTest is BaseAccessControlsTest {
     hooks.setFixedTermEndTime(address(1), 0);
   }
 
-  function test_setFixedTermEndTime_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_setFixedTermEndTime_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     hooks.setFixedTermEndTime(address(1), 0);
   }
 
@@ -569,12 +595,15 @@ contract FixedTermHooksTest is BaseAccessControlsTest {
 
     MarketState memory state;
     state.scaleFactor = uint112(RAY);
+    hooks.addRoleProvider(address(mockProvider1), type(uint32).max);
+    vm.prank(address(mockProvider1));
     hooks.grantRole(address(2), uint32(block.timestamp));
 
     vm.prank(address(1));
     hooks.onDeposit(address(2), 1, state, '');
     assertTrue(hooks.isKnownLenderOnMarket(address(2), address(1)), 'known lender');
 
+    vm.prank(address(mockProvider1));
     hooks.revokeRole(address(2));
     assertEq(hooks.getPreviousLenderStatus(address(2)).lastApprovalTimestamp, 0, 'revoked');
 
@@ -702,8 +731,8 @@ contract FixedTermHooksTest is BaseAccessControlsTest {
     hooks.setMinimumDeposit(address(1), 0);
   }
 
-  function test_setMinimumDeposit_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_setMinimumDeposit_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     hooks.setMinimumDeposit(address(1), 1);
   }
 

--- a/test/access/OpenTermHooks.t.sol
+++ b/test/access/OpenTermHooks.t.sol
@@ -17,10 +17,9 @@ contract OpenTermHooksTest is BaseAccessControlsTest {
 
   function setUp() external {
     hooks = new MockOpenTermHooks(address(this));
-    baseHooks = MockBaseAccessControls(address(hooks));
+    _setUpBaseHooks(MockBaseAccessControls(address(hooks)));
     assertEq(hooks.factory(), address(this), 'factory');
-    assertEq(hooks.borrower(), address(this), 'borrower');
-    _addExpectedProvider(MockRoleProvider(address(this)), type(uint32).max, false);
+    assertEq(hooks.administrator(), address(this), 'administrator');
     _validateRoleProviders();
     // Set block.timestamp to 4:50 am, May 3 2024
     warp(1714737030);
@@ -144,10 +143,32 @@ contract OpenTermHooksTest is BaseAccessControlsTest {
     hooks.onCreateMarket(address(1), address(1), inputs, '');
   }
 
-  function test_onCreateMarket_CallerNotBorrower() external {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_onCreateMarket_CallerNotAdministrator() external {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     DeployMarketInputs memory inputs;
     hooks.onCreateMarket(address(1), address(1), inputs, '');
+  }
+
+  function test_acceptAdministratorTransfer_PreservesHookedMarketConfiguration() external {
+    address marketAddress = address(1);
+    address newAdministrator = address(0xA11CE);
+    DeployMarketInputs memory inputs;
+    inputs.hooks = EmptyHooksConfig.setHooksAddress(address(hooks));
+    hooks.onCreateMarket(address(this), marketAddress, inputs, abi.encode(uint128(100), true));
+    bytes32 marketBefore = keccak256(abi.encode(hooks.getHookedMarket(marketAddress)));
+
+    _transferAdministrator(newAdministrator);
+
+    assertEq(
+      keccak256(abi.encode(hooks.getHookedMarket(marketAddress))),
+      marketBefore,
+      'hooked market'
+    );
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    hooks.setMinimumDeposit(marketAddress, 200);
+    vm.prank(newAdministrator);
+    hooks.setMinimumDeposit(marketAddress, 200);
+    assertEq(hooks.getHookedMarket(marketAddress).minimumDeposit, 200, 'minimum deposit');
   }
 
   function test_onCreateMarket_ForceEnableDepositTransferHooks() external {
@@ -414,8 +435,8 @@ contract OpenTermHooksTest is BaseAccessControlsTest {
     hooks.setMinimumDeposit(address(1), 0);
   }
 
-  function test_setMinimumDeposit_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_setMinimumDeposit_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     hooks.setMinimumDeposit(address(1), 1);
   }
 
@@ -451,12 +472,15 @@ contract OpenTermHooksTest is BaseAccessControlsTest {
 
     MarketState memory state;
     state.scaleFactor = uint112(RAY);
+    hooks.addRoleProvider(address(mockProvider1), type(uint32).max);
+    vm.prank(address(mockProvider1));
     hooks.grantRole(address(2), uint32(block.timestamp));
 
     vm.prank(address(1));
     hooks.onDeposit(address(2), 1, state, '');
     assertTrue(hooks.isKnownLenderOnMarket(address(2), address(1)), 'known lender');
 
+    vm.prank(address(mockProvider1));
     hooks.revokeRole(address(2));
     assertEq(hooks.getPreviousLenderStatus(address(2)).lastApprovalTimestamp, 0, 'revoked');
 

--- a/test/access/PeriodicTermHooks.t.sol
+++ b/test/access/PeriodicTermHooks.t.sol
@@ -34,10 +34,9 @@ contract PeriodicTermHooksTest is BaseAccessControlsTest {
 
   function setUp() external {
     hooks = new MockPeriodicTermHooks(address(this));
-    baseHooks = MockBaseAccessControls(address(hooks));
+    _setUpBaseHooks(MockBaseAccessControls(address(hooks)));
     assertEq(hooks.factory(), address(this), 'factory');
-    assertEq(hooks.borrower(), address(this), 'borrower');
-    _addExpectedProvider(MockRoleProvider(address(this)), type(uint32).max, false);
+    assertEq(hooks.administrator(), address(this), 'administrator');
     _validateRoleProviders();
     warp(PeriodStart);
   }
@@ -257,10 +256,29 @@ contract PeriodicTermHooksTest is BaseAccessControlsTest {
     hooks.onCreateMarket(address(1), Market, inputs, '');
   }
 
-  function test_onCreateMarket_CallerNotBorrower() external {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_onCreateMarket_CallerNotAdministrator() external {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     DeployMarketInputs memory inputs;
     hooks.onCreateMarket(address(1), Market, inputs, '');
+  }
+
+  function test_acceptAdministratorTransfer_PreservesHookedMarketConfiguration() external {
+    address newAdministrator = address(0xA11CE);
+    _createMarket(EmptyHooksConfig, _encodeHooksData(100, true));
+    bytes32 marketBefore = keccak256(abi.encode(hooks.getHookedMarket(Market)));
+
+    _transferAdministrator(newAdministrator);
+
+    assertEq(
+      keccak256(abi.encode(hooks.getHookedMarket(Market))),
+      marketBefore,
+      'hooked market'
+    );
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
+    hooks.setMinimumDeposit(Market, 200);
+    vm.prank(newAdministrator);
+    hooks.setMinimumDeposit(Market, 200);
+    assertEq(hooks.getHookedMarket(Market).minimumDeposit, 200, 'minimum deposit');
   }
 
   function test_onCreateMarket_PeriodicWindowNotProvided() external {
@@ -1001,8 +1019,8 @@ contract PeriodicTermHooksTest is BaseAccessControlsTest {
     hooks.setMinimumDeposit(Market, 0);
   }
 
-  function test_setMinimumDeposit_CallerNotBorrower() external asAccount(address(1)) {
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+  function test_setMinimumDeposit_CallerNotAdministrator() external asAccount(address(1)) {
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     hooks.setMinimumDeposit(Market, 1);
   }
 
@@ -1090,12 +1108,12 @@ contract PeriodicTermHooksTest is BaseAccessControlsTest {
     );
   }
 
-  function test_proposeAnnualInterestBips_CallerNotBorrower() external {
+  function test_proposeAnnualInterestBips_CallerNotAdministrator() external {
     MockAprMarket market = new MockAprMarket(1_000);
     _createMarket(address(market), EmptyHooksConfig, _encodeHooksData());
 
     vm.prank(address(1));
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     hooks.proposeAnnualInterestBips(address(market), 900);
   }
 

--- a/test/helpers/fuzz/AccessControlHooksFuzzContext.sol
+++ b/test/helpers/fuzz/AccessControlHooksFuzzContext.sol
@@ -232,7 +232,7 @@ function createAccessControlHooksFuzzContext(
   context.functionKind = functionKind;
   context.functionInputAmount = amount;
   context.hooks = hooks;
-  context.borrower = hooks.borrower();
+  context.borrower = hooks.administrator();
   context.account = account;
   context.existingCredentialOptions = fuzzInputs.existingCredentialInputs;
   context.dataOptions = fuzzInputs.dataInputs;

--- a/test/integration/MarketConfigMatrix.sol
+++ b/test/integration/MarketConfigMatrix.sol
@@ -179,14 +179,24 @@ contract MarketConfigMatrix is BaseMarketTest {
       );
     }
 
-    // Credential both lenders on the hooks instance.
-    BaseAccessControls(instance).grantRole(alice, uint32(block.timestamp));
-    BaseAccessControls(instance).grantRole(bob, uint32(block.timestamp));
+    BaseAccessControls(instance).addRoleProvider(
+      address(ecdsaRoleProvider),
+      type(uint32).max
+    );
     stopPrank();
+
+    // Credential both lenders through an explicit provider.
+    _grantHookRole(instance, alice);
+    _grantHookRole(instance, bob);
 
     _approveMarket(alice, address(deployed.market));
     _approveMarket(bob, address(deployed.market));
     _approveMarket(borrower, address(deployed.market));
+  }
+
+  function _grantHookRole(address hooksInstance, address account) internal {
+    vm.prank(address(ecdsaRoleProvider));
+    BaseAccessControls(hooksInstance).grantRole(account, uint32(block.timestamp));
   }
 
   function _templateFor(MatrixHooksKind kind) internal view returns (address) {

--- a/test/integration/MinimumDepositScenarios.t.sol
+++ b/test/integration/MinimumDepositScenarios.t.sol
@@ -92,9 +92,9 @@ contract MinimumDepositScenariosTest is MarketConfigMatrix {
     _depositAs(d, alice, 1e18);
     assertEq(d.market.balanceOf(alice), MIN_DEPOSIT + 1e18, 'small deposit after clearing');
 
-    // Only the borrower can move the knob.
+    // Only the hook administrator can move the knob.
     startPrank(alice);
-    vm.expectRevert(BaseAccessControls.CallerNotBorrower.selector);
+    vm.expectRevert(BaseAccessControls.CallerNotAdministrator.selector);
     PeriodicTermHooks(d.hooksInstance).setMinimumDeposit(address(d.market), 1);
     stopPrank();
   }

--- a/test/integration/ProductionMirror.t.sol
+++ b/test/integration/ProductionMirror.t.sol
@@ -189,9 +189,7 @@ contract ProductionMirrorTest is MarketConfigMatrix {
     wrapper.deposit(wrapAmount, alice);
     stopPrank();
 
-    startPrank(borrower);
-    BaseAccessControls(d.hooksInstance).grantRole(address(wrapper), uint32(block.timestamp));
-    stopPrank();
+    _grantHookRole(d.hooksInstance, address(wrapper));
 
     uint256 marketBalanceBefore = d.market.balanceOf(alice);
     startPrank(alice);

--- a/test/integration/WrapperSanctionsScenarios.t.sol
+++ b/test/integration/WrapperSanctionsScenarios.t.sol
@@ -15,9 +15,7 @@ contract WrapperSanctionsScenariosTest is MarketConfigMatrix {
     DeployedCell memory d,
     Wildcat4626Wrapper wrapper
   ) internal returns (Wildcat4626Wrapper) {
-    startPrank(borrower);
-    BaseAccessControls(d.hooksInstance).grantRole(address(wrapper), uint32(block.timestamp));
-    stopPrank();
+    _grantHookRole(d.hooksInstance, address(wrapper));
     return wrapper;
   }
 

--- a/test/shared/Test.sol
+++ b/test/shared/Test.sol
@@ -250,11 +250,11 @@ contract Test is ForgeTest, Prankster, Assertions {
       initCodeHash := keccak256(initCodePointer, initCodeSizeWithArgs)
     }
 
-    uint256 numPreviousInstances = hooksFactory.getHooksInstancesCountForBorrower(borrower);
+    uint256 deploymentNonce = hooksFactory.getHooksInstanceDeploymentNonce(borrower);
     bytes32 salt;
 
     assembly {
-      salt := or(shl(96, borrower), numPreviousInstances)
+      salt := or(shl(96, borrower), deploymentNonce)
     }
 
     return
@@ -289,7 +289,8 @@ contract Test is ForgeTest, Prankster, Assertions {
       vm.expectEmit(address(hooksFactory));
       emit IHooksFactoryEventsAndErrors.HooksInstanceDeployed(
         address(hooksInstance),
-        parameters.hooksTemplate
+        parameters.hooksTemplate,
+        parameters.borrower
       );
       assertEq(
         hooksFactory.deployHooksInstance(


### PR DESCRIPTION
## Summary

Add two-step hook administration with atomic factory reassociation.
Separate hook policy from reusable lender credentials.
Add reusable access-list role providers with independent administration and explicit TTL behavior.

## Testing

forge test: 1,518 passed.
All production contracts remain below the EIP-170 size limit.